### PR TITLE
Allow Open-Event Ticket

### DIFF
--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -63,11 +63,7 @@ function registerDevice() {
     showServerError.value = true
     return
   }
-  if (server.value === 'Open-Event') {
-    errmessage.value = 'Please Login with credentials for Open-Event'
-    showServerError.value = true
-    return
-  }
+  processApi.setServer(server.value)
   showServerError.value = false
   router.push({
     name: 'device'

--- a/src/stores/eventyayapi.js
+++ b/src/stores/eventyayapi.js
@@ -14,6 +14,7 @@ export const useEventyayApi = defineStore(
     const exhiname = ref('')
     const boothname = ref('')
     const boothid = ref('')
+    const servername = ref('')
 
     function $reset() {
       apitoken.value = ''
@@ -50,6 +51,10 @@ export const useEventyayApi = defineStore(
       selectedRole.value = role
     }
 
+    function setServer(server) {
+      servername.value = server
+    }
+
     return {
       $reset,
       setApiCred,
@@ -57,6 +62,7 @@ export const useEventyayApi = defineStore(
       setExhibitor,
       selectedRole,
       setRole,
+      setServer,
       apitoken,
       url,
       organizer,
@@ -65,7 +71,8 @@ export const useEventyayApi = defineStore(
       exikey,
       exhiname,
       boothname,
-      boothid
+      boothid,
+      servername
     }
   },
   {

--- a/src/stores/processEventyayCheckIn.js
+++ b/src/stores/processEventyayCheckIn.js
@@ -98,7 +98,7 @@ export const useProcessEventyayCheckInStore = defineStore('processEventyayCheckI
 
         const printWindow = window.open(blobUrl, '_blank')
         if (printWindow) {
-          printWindow.onload = function () {
+          printWindow.onload = function() {
             printWindow.print()
             URL.revokeObjectURL(blobUrl)
           }
@@ -117,23 +117,43 @@ export const useProcessEventyayCheckInStore = defineStore('processEventyayCheckI
 
   async function checkIn() {
     console.log('Check-in')
-    const qrData = JSON.parse(cameraStore.qrCodeValue)
     const processApi = useEventyayApi()
-    const { apitoken, url, organizer, eventSlug } = processApi
+    const { apitoken, url, organizer, servername, eventSlug } = processApi
+    const qrData = ""
+    if (servername === 'Open-Event') {
+      qrData = cameraStore.qrCodeValue
+    } else {
+      qrData = JSON.parse(cameraStore.qrCodeValue)
+    }
 
     const checkInList = await getlist()
     const nonce = generateNonce()
 
-    const requestBody = {
-      secret: qrData.ticket,
-      source_type: 'barcode',
-      lists: checkInList,
-      force: false,
-      ignore_unpaid: false,
-      nonce: nonce,
-      datetime: null,
-      questions_supported: false
-    }
+	const requestBody = {}
+	
+	if (servername === 'Open-Event') {
+	  requestBody = {
+		secret: qrData,
+		source_type: 'barcode',
+		lists: checkInList,
+		force: false,
+		ignore_unpaid: false,
+		nonce: nonce,
+		datetime: null,
+		questions_supported: false
+	  }
+	} else {
+		requestBody = {
+      	  secret: qrData.ticket,
+      	  source_type: 'barcode',
+          lists: checkInList,
+          force: false,
+          ignore_unpaid: false,
+      	  nonce: nonce,
+      	  datetime: null,
+      	  questions_supported: false
+    	}
+	}
 
     try {
       const headers = {


### PR DESCRIPTION
This PR enables scanning ticket codes from **open-event tickets** which are stored as strings unlike json in the Eventyay.
The Server value is now stored and checked before parsing the json...
```js
    const qrData = ""
    if (servername === 'Open-Event') {
      qrData = cameraStore.qrCodeValue
    } else {
      qrData = JSON.parse(cameraStore.qrCodeValue)
    }
```

## Summary by Sourcery

New Features:
- Added support for scanning ticket codes from Open-Event tickets, which are stored as strings instead of JSON.