### PR TITLE
Possible Camera Fixes

### DIFF
--- a/src/components/Utilities/QRCamera.vue
+++ b/src/components/Utilities/QRCamera.vue
@@ -78,19 +78,12 @@ async function detectedQR([result]) {
 }
 
 function switchCamera() {
-  destroyed.value = true
-  console.log('switchCamera: having the following cameras:')
-  console.log(cameraStore.cameraDevices)
-  console.log('switchCamera: cameraDevices.value = ' + cameraStore.cameraDevices.value)
-  if (cameraStore.cameraDevices.length === 0) {
-    console.log("No cameras found in cameraStore, re-enumerating them")
-    updateAvailableCamera()
-  }
+  console.log('Switching camera...')
+  stopCameraStream()
   cameraStore.toggleCameraSide()
   nextTick(() => {
-    destroyed.value = false
+    startCameraStream()
   })
-  startInactivityTimer()
 }
 
 function toggleCamera() {
@@ -112,6 +105,25 @@ function clearInactivityTimer() {
     clearTimeout(inactivityTimer)
     inactivityTimer = null
   }
+}
+
+// Stop the current camera stream
+function stopCameraStream() {
+  console.log("Stopping Stream")
+  navigator.mediaDevices.getUserMedia({ video: true })
+    .then(stream => {
+      stream.getTracks().forEach(track => track.stop())
+    })
+    .catch(err => console.error("Error stopping camera:", err))
+}
+
+// Restart the camera
+function startCameraStream() {
+  console.log("Restarting Stream")
+  isCameraOn.value = false
+  nextTick(() => {
+    isCameraOn.value = true
+  })
 }
 </script>
 

--- a/src/stores/camera.js
+++ b/src/stores/camera.js
@@ -19,26 +19,38 @@ export const useCameraStore = defineStore('camera', () => {
   }
 
   function toggleCameraSide() {
-    // get length of devices
-    // if length is 1, then toggle is not possible
-    const qty = cameraDevices.value
-    if (qty === 1) {
-      return
-    }
+    if (cameraDevices.value.length < 2) return
 
-    let index = cameraDevices.value.findIndex((device) => {
-      return device.id === selectedCameraId.value.deviceId
-    })
+    let currentIndex = cameraDevices.value.findIndex(device => 
+      device.id === selectedCameraId.value.deviceId
+    )
 
-    // selected device is the next index
-    const nextIndex = index + 1
-    // if next index is the last index, then select the first index
-    if (nextIndex === cameraDevices.value.length) {
-      selectedCameraId.value.deviceId = cameraDevices.value[0].id
-      return
-    }
-    // else select the next index
+    // Select the next camera in the list (loop back if at the end)
+    const nextIndex = (currentIndex + 1) % cameraDevices.value.length
     selectedCameraId.value.deviceId = cameraDevices.value[nextIndex].id
+
+    // Stop the current camera stream before switching
+    stopCameraStream()
+
+    // Restart camera after a short delay
+    setTimeout(() => {
+      startCameraStream()
+    }, 500) // Ensures proper switching
+  }
+
+  function stopCameraStream() {
+    navigator.mediaDevices.getUserMedia({ video: true })
+      .then(stream => {
+        stream.getTracks().forEach(track => track.stop()) // Stop all video tracks
+      })
+      .catch(err => console.error("Error stopping camera:", err))
+  }
+
+  function startCameraStream() {
+    paused.value = true
+    setTimeout(() => {
+      paused.value = false
+    }, 300) // Ensures Vue updates the state properly
   }
 
   function paintOutline(detectedCodes, ctx) {
@@ -79,6 +91,8 @@ export const useCameraStore = defineStore('camera', () => {
     $reset,
     toggleCameraSide,
     selected,
-    logErrors
+    logErrors,
+    stopCameraStream,
+    startCameraStream
   }
 })


### PR DESCRIPTION
This PR aims to fix the Camera Toggle Issues

## Summary by Sourcery

Improves camera switching by ensuring the camera stream is stopped before switching to another camera and restarted after a short delay. This prevents issues with the camera not switching properly.

Enhancements:
- Improves camera switching by stopping the current camera stream before switching and restarting it after a delay to ensure proper switching.
- Adds functions to explicitly start and stop the camera stream.