### PR TITLE
Modify Check-In Staff page

### DIFF
--- a/src/components/Eventyay/EventyayEvents.vue
+++ b/src/components/Eventyay/EventyayEvents.vue
@@ -61,22 +61,37 @@ const categorizedEvents = computed(() => {
 })
 
 const submitForm = () => {
-  if (selectedEvent.value) {
-    const selectedEventData = events.value.find((event) => event.slug === selectedEvent.value)
-    if (selectedEventData) {
-      console.log('Selected Event:', selectedEventData)
-      console.log('Selected Role:', selectedRole)
-      processApi.setEvent(selectedEventData.slug, selectedEventData.name.en)
-      if (selectedRole === 'Exhibitor') router.push({ name: 'eventyayleedlogin' })
-      if (selectedRole === 'Badge Station') router.push({ name: 'eventyaycheckin' })
-	  if (selectedRole === 'CheckIn') router.push({name: 'eventyaysearchcheckin'})
-	} else {
-	  console.error('Event not found.')
-    }
-  } else {
+  if (!selectedEvent.value) {
     console.error('Please select an event.')
+    return
+  }
+
+  const selectedEventData = events.value.find(event => event.slug === selectedEvent.value)
+
+  if (!selectedEventData) {
+    console.error('Event not found.')
+    return
+  }
+
+  console.log('Selected Event:', selectedEventData)
+  console.log('Selected Role:', selectedRole)
+
+  processApi.setEvent(selectedEventData.slug, selectedEventData.name.en)
+
+  const routeMap = {
+    'Exhibitor': 'eventyayleedlogin',
+    'Badge Station': 'eventyaycheckin',
+    'CheckIn': 'eventyaysearchcheckin'
+  }
+
+  const routeName = routeMap[selectedRole]
+  if (routeName) {
+    router.push({ name: routeName })
+  } else {
+    console.warn('Unhandled role:', selectedRole)
   }
 }
+
 </script>
 
 <template>

--- a/src/components/Eventyay/EventyayEvents.vue
+++ b/src/components/Eventyay/EventyayEvents.vue
@@ -68,8 +68,10 @@ const submitForm = () => {
       console.log('Selected Role:', selectedRole)
       processApi.setEvent(selectedEventData.slug, selectedEventData.name.en)
       if (selectedRole === 'Exhibitor') router.push({ name: 'eventyayleedlogin' })
-      if (selectedRole === 'CheckIn' || selectedRole === 'Badge Station')
-        router.push({ name: 'eventyaycheckin' })
+      if (selectedRole === 'Badge Station') router.push({ name: 'eventyaycheckin' })
+	  if (selectedRole === 'CheckIn') router.push({name: 'eventyaysearchcheckin'})
+	} else {
+	  console.error('Event not found.')
     }
   } else {
     console.error('Please select an event.')

--- a/src/components/Eventyay/EventyaySearchCheckIn.vue
+++ b/src/components/Eventyay/EventyaySearchCheckIn.vue
@@ -4,7 +4,9 @@ import { useEventyayApi } from '@/stores/eventyayapi'
 import { mande } from 'mande'
 import QRCamera from '@/components/Common/QRCamera.vue'
 import { useLoadingStore } from '@/stores/loading'
+import { useNotificationStore } from '@/stores/notification'
 
+const notificationStore = useNotificationStore()
 const processApi = useEventyayApi()
 const { apitoken, url, organizer, eventSlug } = processApi
 
@@ -19,6 +21,22 @@ api.options.headers = {
 const searchQuery = ref('')
 const orders = ref([])
 const loading = ref(false)
+const baseUrl = `${url}/api/v1/organizers/${organizer}/events/${eventSlug}`
+const fetchAllOrders = async (url, accumulatedOrders = []) => {
+  console.log('Fetching orders from URL:', url)
+  const response = await api.get(url)
+  console.log('Fetched orders:', response)
+  const newOrders = accumulatedOrders.concat(response.results)
+
+  if (response.next) {
+	console.log('Next URL:', response.next)
+	const nextUrl = response.next.replace(`${baseUrl}`, '')  // Remove the current URL part to get the relative path
+	console.log('Next URL after removal of base prefix:', nextUrl)
+    return fetchAllOrders(nextUrl, newOrders)
+  } else {
+    return newOrders
+  }
+}
 
 const searchOrders = async () => {
   if (!searchQuery.value) {
@@ -27,11 +45,10 @@ const searchOrders = async () => {
   }
 
   loading.value = true
+  notificationStore.addNotification(['Fetching orders...'], 'success')
   try {
-    const response = await api.get('orderpositions/')
-
-    // Filter results based on search query
-    orders.value = response.results.filter(
+    const allOrders = await fetchAllOrders('orderpositions/')
+    orders.value = allOrders.filter(
       (order) =>
         order.attendee_name?.toLowerCase().includes(searchQuery.value.toLowerCase()) ||
         order.attendee_email?.toLowerCase().includes(searchQuery.value.toLowerCase())

--- a/src/stores/notification.js
+++ b/src/stores/notification.js
@@ -1,11 +1,34 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
+let idCounter = 0
+
 export const useNotificationStore = defineStore('notification', () => {
   const list = ref([])
 
-  function addNotification(messages, type) {
-    list.value.push({ messages: messages, type: type })
+  function addNotification(messages, type, duration = 3000) {
+    // Remove existing identical notifications
+    list.value = list.value.filter(
+      (n) => n.messages.join('') !== messages.join('') || n.type !== type
+    )
+
+    const id = idCounter++
+    const notification = { id, messages, type }
+    list.value.push(notification)
+
+    // Auto-remove after duration
+    setTimeout(() => {
+      removeNotification(id)
+    }, duration)
   }
-  return { list, addNotification }
+
+  function removeNotification(id) {
+    list.value = list.value.filter((n) => n.id !== id)
+  }
+
+  function clearNotifications() {
+    list.value = []
+  }
+
+  return { list, addNotification, removeNotification, clearNotifications }
 })


### PR DESCRIPTION
### This PR modifies a few things

- The `Check-In staff` are now directly routed to the `Search and Check-In` Page instead of the default Badge Printing Page.
   <img width="1578" alt="image" src="https://github.com/user-attachments/assets/66e368d1-426b-4ec2-9ee9-e9d848002a1c" />



- The notification system has been updated to show `toast` like notifications during search.<img width="1578" alt="image" src="https://github.com/user-attachments/assets/b24f8b5d-2c33-4e4e-8105-eba95bfe6934" />


- The Search function has been temporarily updated to prefetch all orders and resolves the previous pagination issue until a dedicated a search api is made.

## Summary by Sourcery

Modify Check-In workflow by redirecting Check-In staff to the Search and Check-In page, enhancing notifications to toast-style with auto-removal, and implementing full order prefetching to work around pagination limits

New Features:
- Route Check-In staff directly to the Search and Check-In page instead of the default badge printing page
- Introduce recursive order prefetching in the Search function to temporarily resolve pagination issues

Bug Fixes:
- Resolve pagination issue by fetching all orders before filtering

Enhancements:
- Update notification store to show toast-style notifications with deduplication and auto-dismiss support