### PR TITLE
fix(checkin): update lead scanning api's and remove console.logs

### DIFF
--- a/src/components/Common/BadgePrintPreview.vue
+++ b/src/components/Common/BadgePrintPreview.vue
@@ -32,7 +32,6 @@ const fetchPDF = async () => {
       },
       credentials: 'include'
     })
-    console.log('Response:', response)
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`)
     }

--- a/src/components/Common/TagInput.vue
+++ b/src/components/Common/TagInput.vue
@@ -18,7 +18,7 @@ const { availableTags, currentTags, inputValue } = storeToRefs(tagStore)
 onMounted(() => {
   tagStore.fetchTags()
 })
-console.log(availableTags)
+
 function handleInput(e) {
   tagStore.handleCommaInput(e.target.value)
   emit('update:modelValue', currentTags.value)

--- a/src/components/Eventyay/EventyayEvents.vue
+++ b/src/components/Eventyay/EventyayEvents.vue
@@ -55,7 +55,7 @@ const categorizedEvents = computed(() => {
 
   // Filter for exhibitor events if role is Exhibitor
   if (selectedRole === 'Exhibitor') {
-    filteredEvents = events.value.filter((event) => event.plugins && event.plugins.includes('exhibitors'))
+    filteredEvents = events.value.filter((event) => event.plugins && event.plugins.includes('exhibition'))
   }
 
   // For CheckIn or Badge Station, only show upcoming events

--- a/src/components/Eventyay/EventyayLeedLogin.vue
+++ b/src/components/Eventyay/EventyayLeedLogin.vue
@@ -23,7 +23,6 @@ async function submitLogin() {
     key: password.value
   }
   const response = await leedauth.leedlogin(payload)
-  console.log(response)
   if (response.success) {
     router.push({ name: 'leadscan' })
   } else {

--- a/src/components/Eventyay/LeadScanning.vue
+++ b/src/components/Eventyay/LeadScanning.vue
@@ -52,7 +52,7 @@ function handleNotesInput() {
 async function handleSave() {
   const { url, organizer, eventSlug, apitoken, exikey } = processApi
   const api = mande(
-    `${url}/api/v1/event/${organizer}/${eventSlug}/exhibitors/lead/${currentLeadId.value}/update`,
+    `${url}api/v1/event/${organizer}/${eventSlug}/exhibitors/lead/${currentLeadId.value}/update`,
     {
       headers: {
         Authorization: `Device ${apitoken}`,

--- a/src/stores/leadscan.js
+++ b/src/stores/leadscan.js
@@ -69,7 +69,6 @@ export const useLeadScanStore = defineStore('processLeadScan', () => {
       })
 
       const response = await api.post(requestBody)
-      console.log('here', response)
       if (response.success) {
         showSuccessMsg({
           message: 'Lead Scanned Successfully!',
@@ -96,7 +95,6 @@ export const useLeadScanStore = defineStore('processLeadScan', () => {
   }
 
   function downloadCSV(leads) {
-    console.log('Downloading CSV')
     const csvData = convertToCSV(leads)
     const blob = new Blob([csvData], { type: 'text/csv;charset=utf-8;' })
     const url = URL.createObjectURL(blob)
@@ -110,7 +108,6 @@ export const useLeadScanStore = defineStore('processLeadScan', () => {
   }
 
   function convertToCSV(leads) {
-    console.log('Converting to CSV')
     const formatDate = (date) => new Date(date).toISOString().split('T')[0]
     const formatTime = (date) => new Date(date).toISOString().split('T')[1].split('.')[0]
     const headers = [
@@ -167,7 +164,6 @@ export const useLeadScanStore = defineStore('processLeadScan', () => {
   }
 
   async function exportLeads() {
-    console.log('Exporting leads')
     const processApi = useEventyayApi()
     const { apitoken, url, organizer, eventSlug, exikey } = processApi
 
@@ -177,7 +173,7 @@ export const useLeadScanStore = defineStore('processLeadScan', () => {
         Accept: 'application/json',
         Exhibitor: exikey
       }
-      const api = mande(`${url}/api/v1/event/${organizer}/${eventSlug}/exhibitors/lead/retrieve`, {
+      const api = mande(`${url}api/v1/event/${organizer}/${eventSlug}/exhibitors/lead/retrieve`, {
         headers: headers
       })
       const response = await api.get()

--- a/src/stores/leedauth.js
+++ b/src/stores/leedauth.js
@@ -17,7 +17,6 @@ export const useleedauth = defineStore('leedauth', () => {
         `/api/v1/event/${organizer}/${eventSlug}/exhibitors/auth`,
         payload
       )
-      console.log(response)
       if (response.success) {
         processApi.setExhibitor(
           payload.key,
@@ -29,7 +28,7 @@ export const useleedauth = defineStore('leedauth', () => {
 
       return response
     } catch (error) {
-      console.log('error')
+      console.log(error)
     }
   }
 

--- a/src/stores/processDevice.js
+++ b/src/stores/processDevice.js
@@ -316,7 +316,6 @@ export const useProcessDeviceStore = defineStore('processDevice', () => {
         apiStore.newSession(true)
         const data = response
         showSuccessMsg()
-        console.log(data)
         processApi.setApiCred(data.api_token, url, data.organizer)
         router.push({ name: 'eventyayevents' })
       } else {

--- a/src/stores/tags.js
+++ b/src/stores/tags.js
@@ -13,7 +13,7 @@ export const useTagStore = defineStore('tags', () => {
     const { url, organizer, eventSlug, apitoken, exikey } = processApi
 
     try {
-      const api = mande(`${url}/api/v1/event/${organizer}/${eventSlug}/exhibitors/tags`, {
+      const api = mande(`${url}api/v1/event/${organizer}/${eventSlug}/exhibitors/tags`, {
         headers: {
           Authorization: `Device ${apitoken}`,
           Accept: 'application/json',


### PR DESCRIPTION
Related to PR https://github.com/fossasia/eventyay-exhibition/pull/24

<img width="1578" height="1030" alt="image" src="https://github.com/user-attachments/assets/c489b546-6058-4d69-a311-08611fad1175" />

## Summary by Sourcery

Update lead scanning-related APIs and clean up logging across the check-in and exhibitor flows.

Bug Fixes:
- Correct exhibitor lead retrieval, lead update, and tag management API endpoint URLs.
- Adjust exhibitor event filtering to use the correct plugin identifier.
- Log full error details in the lead authentication store instead of a generic message.

Enhancements:
- Remove unnecessary console logging from lead scanning, CSV export, tag input, badge preview, login, and device processing flows to reduce noise in production logs.