### PR TITLE
fix(blob): add check for blob response

### DIFF
--- a/src/stores/processEventyayCheckIn.js
+++ b/src/stores/processEventyayCheckIn.js
@@ -83,12 +83,22 @@ export const useProcessEventyayCheckInStore = defineStore('processEventyayCheckI
         }
       })
 
-      const response = await api.get(badgeUrl)
-      return response
-    } catch (error) {
-      if (error.response?.status === 406) {
+	  const response = await api.get(badgeUrl)
+      const blob = new Blob([response], { type: 'application/pdf' })
+
+      if (blob.size > 0) {
+        return response
+      }
+
+      return null
+    } 
+	catch (error) {
+      const status = error?.response?.status || error?.status
+
+      if (status === 406 || status === 409 || status === 202) {
         return null
       }
+
       throw error
     }
   }
@@ -102,11 +112,13 @@ export const useProcessEventyayCheckInStore = defineStore('processEventyayCheckI
 
     try {
       let badgeResponse = await getBadgeStatus(badgeUrl)
-      if (!badgeResponse) {
+      let blob = new Blob([badgeResponse], { type: 'application/pdf' })
+      if (blob.size == 0) {
         for (let i = 0; i < 5; i++) {
           await new Promise((resolve) => setTimeout(resolve, 1000))
           badgeResponse = await getBadgeStatus(badgeUrl)
-          if (badgeResponse) break
+          blob = new Blob([badgeResponse], { type: 'application/pdf' })
+          if (blob.size > 0) break
         }
       }
 
@@ -114,7 +126,6 @@ export const useProcessEventyayCheckInStore = defineStore('processEventyayCheckI
         return false
       }
 
-      const blob = new Blob([badgeResponse], { type: 'application/pdf' })
       const blobUrl = URL.createObjectURL(blob)
       console.log('Opening badge for printing:', blobUrl)
 


### PR DESCRIPTION
Mande does not return a real HTTP Response here, it just hands back the raw payload, so checking response.status on a PDF response was not working and kept the badge polling loop running even after the badge had already been generated.

This change leans into that behaviour instead of fighting it: treat the returned value as the PDF payload, wrap it in a Blob, and use the Blob size to decide whether the badge is ready. If the Blob has content, stop polling immediately and print it.

As a result, the check-in flow no longer keeps sending completely unnecessary requests after the badge response has already been received. Printing still uses mande and the existing blob URL flow, so it avoids opening an extra visible PDF tab/window while still opening the browser print window as expected. Switching to `fetch` gets the proper response which makes the browser open the pdf in a separate window which is bad for silent printing.

## Summary by Sourcery

Handle badge PDF polling based on the actual PDF payload instead of HTTP response status when using the Mande client.

Bug Fixes:
- Stop the check-in badge polling loop once a non-empty PDF payload is returned instead of relying on HTTP status codes that are not available from Mande responses.
- Treat specific non-success HTTP-like status codes (406, 409, 202) as non-fatal, allowing the polling process to continue instead of throwing prematurely.

Enhancements:
- Use Blob size checks to determine badge readiness and avoid unnecessary repeated badge status requests during check-in.