### PR TITLE
fix: resolve stale role and session expiry issues

### DIFF
--- a/src/components/Eventyay/EventyayEvents.vue
+++ b/src/components/Eventyay/EventyayEvents.vue
@@ -171,8 +171,8 @@ const submitForm = () => {
 
   const routeMap = {
     'Exhibitor': 'eventyayleedlogin',
-    'Badge Station': 'eventyaycheckin',
-    'CheckIn': 'eventyaysearchcheckin'
+    'Badge Station': 'eventyaysearchcheckin',
+    'CheckIn': 'eventyaycheckin'
   }
 
   const routeName = routeMap[selectedRole]

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,19 @@ import { createApp } from 'vue'
 
 import '@/style.css'
 
+// Setup global fetch interceptor to catch 401 session expiry
+const originalFetch = window.fetch
+window.fetch = async (...args) => {
+  const response = await originalFetch(...args)
+  if (response.status === 401) {
+    localStorage.clear()
+    if (window.location.pathname !== '/') {
+      window.location.href = '/'
+    }
+  }
+  return response
+}
+
 const app = createApp(App)
 
 const pinia = createPinia()

--- a/src/main.js
+++ b/src/main.js
@@ -8,16 +8,46 @@ import { createApp } from 'vue'
 
 import '@/style.css'
 
-// Setup global fetch interceptor to catch 401 session expiry
+// Setup global fetch interceptor to catch 401 session expiry for API calls
 const originalFetch = window.fetch
 window.fetch = async (...args) => {
   const response = await originalFetch(...args)
-  if (response.status === 401) {
-    localStorage.clear()
-    if (window.location.pathname !== '/') {
-      window.location.href = '/'
+
+  try {
+    const [input] = args
+    const url =
+      input instanceof Request
+        ? input.url
+        : typeof input === 'string' || input instanceof URL
+        ? String(input)
+        : null
+
+    const apiBaseUrlProd = import.meta?.env?.VITE_PROD_API_URL
+    const apiBaseUrlTest = import.meta?.env?.VITE_TEST_API_URL
+    
+    const isApiCall =
+      url != null &&
+      (
+        (apiBaseUrlProd && url.startsWith(apiBaseUrlProd)) ||
+        (apiBaseUrlTest && url.startsWith(apiBaseUrlTest)) ||
+        url.startsWith('/api/') ||
+        (url.startsWith(window.location.origin) && url.includes('/api/')) ||
+        url.includes('/api/v1/')
+      )
+
+    if (isApiCall && response.status === 401) {
+      // Remove only our auth/session-related keys to avoid clearing unrelated localStorage data
+      localStorage.removeItem('token')
+      localStorage.removeItem('eventyayapi')
+      
+      if (window.location.pathname !== '/') {
+        window.location.href = '/'
+      }
     }
+  } catch {
+    // If URL inspection fails for any reason, fall back to returning the response
   }
+
   return response
 }
 


### PR DESCRIPTION
Fixes #91 


#  Stale Role and Session Expiry Bug

The underlying cause of the issue described as "application unexpectedly redirects the user or changes their role to Badge Station" had two core components which have now been successfully resolved.

## What was Changed

### 1. Unified Route Mappings
The routes configured in `EventyayEvents.vue` did not match the actual routes evaluated in `LoginForm.vue`. 
* Previously, CheckIn Staff were routed to the Badge Station UI initially, but when the app was refreshed (going through `LoginForm.vue`), it realized they were a CheckIn Staff and loaded the correct QR scanner UI. This gave the illusion that their role was changing or defaulting unexpectedly, when it was actually inconsistent routing across the app.
* **Fix**: Mapped `CheckIn` to `eventyaycheckin` and `Badge Station` to `eventyaysearchcheckin` across the board, matching the intended design.

### 2. Global Session Expiry Handling
Because the app relies on independent instances of the `mande` fetch wrapper across different modules (`eventyayEvent.js`, `processEventyayCheckIn.js`, `tags.js`, etc.), there was no central interceptor for 401s when device sessions expired.
* **Fix**: Implemented a global `window.fetch` interceptor in `src/main.js`. Now, anytime a request returns a `401 Unauthorized` status (which happens when keeping the device signed in for too long and the API token expires), it globally clears `localStorage` (purging stale state/roles) and redirects the user safely back to the Login screen.


