### PR TITLE
Fix Lead scanning API

### DIFF
--- a/src/components/Eventyay/LeadScanning.vue
+++ b/src/components/Eventyay/LeadScanning.vue
@@ -51,19 +51,16 @@ function handleNotesInput() {
 
 async function handleSave() {
   const { url, organizer, eventSlug, apitoken, exikey } = processApi
-  const api = mande(
-    `${url}api/v1/event/${organizer}/${eventSlug}/exhibitors/lead/${currentLeadId.value}/update`,
-    {
-      headers: {
-        Authorization: `Device ${apitoken}`,
-        Accept: 'application/json',
-        Exhibitor: exikey
-      }
+  const api = mande(url, {
+    headers: {
+      Authorization: `Device ${apitoken}`,
+      Accept: 'application/json',
+      Exhibitor: exikey
     }
-  )
+  })
 
   try {
-    await api.post({
+    await api.post(`/api/v1/event/${organizer}/${eventSlug}/exhibitors/lead/${currentLeadId.value}/update`, {
       note: notes.value,
       tags: currentTags.value
     })
@@ -80,9 +77,8 @@ function handleCancel() {
   leadScanStore.$reset()
 }
 
-// Show popup for success or when we have attendee info (409 case)
 watch([showSuccess, showError], ([newSuccess, newError]) => {
-  if (newSuccess || (newError && message.value.attendee)) {
+  if (newSuccess || newError) {
     showPopup()
   }
 })
@@ -114,7 +110,7 @@ function showPopup() {
     />
     <!-- Attendee Info Popup Modal -->
     <div
-      v-if="(showSuccess || showError) && message.attendee"
+      v-if="showSuccess || showError"
       class="fixed inset-0 flex items-center justify-center"
     >
       <div class="relative w-1/3 rounded bg-white p-5 shadow-lg">
@@ -128,7 +124,7 @@ function showPopup() {
         <h2 :class="showError ? 'mb-2 text-xl text-danger' : 'mb-2 text-xl text-success'">
           {{ message.message }}
         </h2>
-        <div>
+        <div v-if="message.attendee">
           <p><b>Name:</b> {{ message.attendee.name || 'No name provided' }}</p>
           <p><b>Email:</b> {{ message.attendee.email || 'No email provided' }}</p>
           <div class="mt-2" @click="handleNotesInput">

--- a/src/stores/leadscan.js
+++ b/src/stores/leadscan.js
@@ -16,6 +16,7 @@ export const useLeadScanStore = defineStore('processLeadScan', () => {
     message.value = ''
     showSuccess.value = false
     showError.value = false
+    cameraStore.qrCodeValue = ''
   }
 
   function showErrorMsg(msg) {
@@ -50,11 +51,14 @@ export const useLeadScanStore = defineStore('processLeadScan', () => {
         Exhibitor: exikey
       }
 
-      const api = mande(`${url}api/v1/event/${organizer}/${eventSlug}/exhibitors/lead/create`, {
+      const api = mande(url, {
         headers: headers
       })
 
-      const response = await api.post(requestBody)
+      const response = await api.post(
+        `/api/v1/event/${organizer}/${eventSlug}/exhibitors/lead/create`,
+        requestBody
+      )
       if (response.success) {
         showSuccessMsg({
           message: 'Lead Scanned Successfully!',
@@ -159,10 +163,10 @@ export const useLeadScanStore = defineStore('processLeadScan', () => {
         Accept: 'application/json',
         Exhibitor: exikey
       }
-      const api = mande(`${url}api/v1/event/${organizer}/${eventSlug}/exhibitors/lead/retrieve`, {
+      const api = mande(url, {
         headers: headers
       })
-      const response = await api.get()
+      const response = await api.get(`/api/v1/event/${organizer}/${eventSlug}/exhibitors/lead/retrieve`)
       if (response.success) {
         downloadCSV(response.leads)
       }

--- a/src/stores/tags.js
+++ b/src/stores/tags.js
@@ -13,7 +13,7 @@ export const useTagStore = defineStore('tags', () => {
     const { url, organizer, eventSlug, apitoken, exikey } = processApi
 
     try {
-      const api = mande(`${url}api/v1/event/${organizer}/${eventSlug}/exhibitors/tags`, {
+      const api = mande(url, {
         headers: {
           Authorization: `Device ${apitoken}`,
           Accept: 'application/json',
@@ -21,7 +21,7 @@ export const useTagStore = defineStore('tags', () => {
         }
       })
 
-      const response = await api.get()
+      const response = await api.get(`/api/v1/event/${organizer}/${eventSlug}/exhibitors/tags`)
       if (response.success) {
         availableTags.value = response.tags
       }


### PR DESCRIPTION
fixes #121


https://github.com/user-attachments/assets/7d5c6e9b-4c44-48a9-8dfb-ada63bb61048

## Summary by Sourcery

Fix lead scanning API interactions and popup behavior for exhibitor leads.

Bug Fixes:
- Correct lead scanning API base URL usage by moving endpoints into request paths for create, update, retrieve, and tag operations.
- Ensure success/error popup is shown for all error responses, not only those including attendee data.
- Reset scanned QR code value when clearing lead scan state to avoid stale scans.

Enhancements:
- Show attendee details conditionally within the popup while always displaying generic success/error messages.