### PR TITLE
feat(checkin): add device registration and shared API utilities

### DIFF
--- a/src/components/Common/KioskLauncherInstructions.vue
+++ b/src/components/Common/KioskLauncherInstructions.vue
@@ -1,0 +1,119 @@
+<script setup>
+import { computed, ref } from 'vue'
+import StandardButton from '@/components/Common/StandardButton.vue'
+import {
+  buildChromeKioskCommand,
+  buildFirefoxKioskCommand,
+  getPlatformLabel,
+  getShellLabel
+} from '@/utils/kioskLauncher'
+import { useNotificationStore } from '@/stores/notification'
+
+const props = defineProps({
+  targetUrl: {
+    type: String,
+    required: true
+  },
+  intro: {
+    type: String,
+    default: ''
+  },
+  showRegistrationSteps: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const notificationStore = useNotificationStore()
+const copiedKioskCommand = ref('')
+const chromeKioskCommand = computed(() => buildChromeKioskCommand(props.targetUrl))
+const firefoxKioskCommand = computed(() => buildFirefoxKioskCommand(props.targetUrl))
+const kioskPlatformLabel = computed(() => getPlatformLabel())
+const kioskShellLabel = computed(() => getShellLabel())
+
+async function copyKioskCommand(command, label) {
+  try {
+    await navigator.clipboard.writeText(command)
+    copiedKioskCommand.value = label
+    setTimeout(() => {
+      copiedKioskCommand.value = ''
+    }, 2000)
+  } catch {
+    notificationStore.addNotification(
+      ['Copy failed', 'Select the command below and copy it manually.'],
+      'warning'
+    )
+  }
+}
+</script>
+
+<template>
+  <div>
+    <p v-if="intro" class="text-center text-xs text-body-muted leading-relaxed">
+      {{ intro }}
+    </p>
+    <p v-else class="text-center text-xs text-body-muted leading-relaxed">
+      Commands for {{ kioskPlatformLabel }}. Run one in {{ kioskShellLabel }}, then continue below.
+    </p>
+
+    <ol
+      v-if="showRegistrationSteps"
+      class="mt-3 space-y-2 text-left text-xs leading-relaxed text-body-muted list-decimal list-inside"
+    >
+      <li>Copy and run the Chrome command below to open kiosk mode.</li>
+      <li>In that window, register this device.</li>
+    </ol>
+
+    <ul v-else class="mt-3 space-y-1.5 text-left text-xs leading-relaxed text-body-muted">
+      <li class="flex gap-2">
+        <span class="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-primary" aria-hidden="true" />
+        <span>Fullscreen kiosk mode</span>
+      </li>
+      <li class="flex gap-2">
+        <span class="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-primary" aria-hidden="true" />
+        <span>Silent printing without a print dialog</span>
+      </li>
+      <li class="flex gap-2">
+        <span class="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-primary" aria-hidden="true" />
+        <span>Use the same browser profile you register in</span>
+      </li>
+    </ul>
+
+    <div class="mt-4 space-y-3 text-left">
+      <div class="rounded-xl border border-surface-border bg-surface-muted p-3">
+        <div class="flex flex-wrap items-center gap-1.5">
+          <p class="text-xs font-semibold text-body">Google Chrome</p>
+          <span
+            class="rounded-full bg-primary/10 px-1.5 py-px text-[9px] font-semibold uppercase tracking-wide text-primary"
+          >
+            Recommended
+          </span>
+        </div>
+        <pre
+          class="mt-2 overflow-x-auto rounded-lg bg-surface px-2.5 py-1.5 text-[10px] leading-snug text-body"
+        >{{ chromeKioskCommand }}</pre>
+        <StandardButton
+          type="button"
+          :text="copiedKioskCommand === 'chrome' ? 'Copied' : 'Copy Chrome command'"
+          class="btn-primary mt-2 w-full justify-center"
+          size="sm"
+          @click="copyKioskCommand(chromeKioskCommand, 'chrome')"
+        />
+      </div>
+
+      <div class="rounded-xl border border-surface-border bg-surface-muted p-3">
+        <p class="text-xs font-semibold text-body">Mozilla Firefox</p>
+        <pre
+          class="mt-2 overflow-x-auto rounded-lg bg-surface px-2.5 py-1.5 text-[10px] leading-snug text-body"
+        >{{ firefoxKioskCommand }}</pre>
+        <StandardButton
+          type="button"
+          :text="copiedKioskCommand === 'firefox' ? 'Copied' : 'Copy Firefox command'"
+          class="btn-white mt-2 w-full justify-center"
+          size="sm"
+          @click="copyKioskCommand(firefoxKioskCommand, 'firefox')"
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/Common/StandardButton.vue
+++ b/src/components/Common/StandardButton.vue
@@ -1,4 +1,6 @@
 <script setup>
+import { computed, useAttrs } from 'vue'
+
 const props = defineProps({
   type: {
     type: String,
@@ -14,19 +16,69 @@ const props = defineProps({
   },
   icon: {
     type: Function,
-    default: () => null
+    default: null
   },
   iconAfter: {
     type: Function,
-    default: () => null
+    default: null
+  },
+  variant: {
+    type: String,
+    default: 'primary',
+    validator: (value) =>
+      ['primary', 'secondary', 'success', 'danger', 'warning', 'info', 'white', 'ghost'].includes(value)
+  },
+  size: {
+    type: String,
+    default: 'md',
+    validator: (value) => ['sm', 'md', 'lg'].includes(value)
+  },
+  block: {
+    type: Boolean,
+    default: false
   }
+})
+
+defineOptions({
+  inheritAttrs: false
+})
+
+const attrs = useAttrs()
+
+const variantClass = computed(() => {
+  const variants = {
+    primary: 'btn-primary',
+    secondary: 'btn-secondary',
+    success: 'btn-success',
+    danger: 'btn-danger',
+    warning: 'btn-warning',
+    info: 'btn-info',
+    white: 'btn-white',
+    ghost: 'btn-ghost'
+  }
+  return variants[props.variant] || variants.primary
+})
+
+const sizeClass = computed(() => {
+  const sizes = {
+    sm: 'px-3 py-1.5 text-xs',
+    md: 'px-4 py-2.5 text-sm',
+    lg: 'px-5 py-3 text-base'
+  }
+  return sizes[props.size] || sizes.md
 })
 </script>
 
 <template>
-  <button :type="type" :disabled="disabled" class="inline-flex items-center">
-    <component :is="icon" v-if="icon" :class="[text !== '' ? 'mr-1 h-5' : 'h-5']" />
-    <span>{{ text }}</span>
-    <component :is="iconAfter" v-if="iconAfter" :class="[text !== '' ? 'ml-1 h-5' : 'h-5']" />
+  <button
+    :type="type"
+    :disabled="disabled"
+    class="inline-flex items-center justify-center gap-2 rounded-xl font-semibold shadow-sm transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:pointer-events-none disabled:opacity-60"
+    :class="[variantClass, sizeClass, block ? 'w-full' : '']"
+    v-bind="attrs"
+  >
+    <component :is="icon" v-if="icon" class="h-5 w-5 shrink-0" />
+    <span v-if="text">{{ text }}</span>
+    <component :is="iconAfter" v-if="iconAfter" class="h-5 w-5 shrink-0" />
   </button>
 </template>

--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -1,116 +1,384 @@
 <script setup>
-import { ref, onMounted } from 'vue'
-import { useRouter } from 'vue-router'
-import { useLoadingStore } from '@/stores/loading'
-import { useAuthStore } from '@/stores/auth'
-import { useUserStore } from '@/stores/user'
-import { useEventyayApi } from '@/stores/eventyayapi'
+import { computed, onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import QRCamera from '@/components/Utilities/QRCamera.vue'
 import StandardButton from '@/components/Common/StandardButton.vue'
+import KioskLauncherInstructions from '@/components/Common/KioskLauncherInstructions.vue'
+import { useCameraStore } from '@/stores/camera'
+import { useEventyayApi } from '@/stores/eventyayapi'
+import { useLoadingStore } from '@/stores/loading'
+import { getEventyayLogoProps, getRoleLabel, getRoleRouteName, STATION_TYPE_DEFINITIONS } from '@/utils/session'
+import { isRoleAllowedForProfile, getAllowedRolesForProfile } from '@/utils/deviceProfiles'
+import { buildKioskUrl, isKioskEnvironment } from '@/utils/kioskLauncher'
+import { UserGroupIcon, PrinterIcon, BuildingStorefrontIcon } from '@heroicons/vue/24/outline'
 
-// stores
 const loadingStore = useLoadingStore()
-const authStore = useAuthStore()
-const userStore = useUserStore()
 const processApi = useEventyayApi()
-
-const email = ref('')
-const password = ref('')
-const showError = ref(false)
-// router
+const cameraStore = useCameraStore()
 const router = useRouter()
+const route = useRoute()
 
-if(processApi.apitoken) {
-	if(processApi.selectedRole === "Exhibitor") {
-		router.push({
-			name: 'leadscan'
-		})
-	} else if(processApi.selectedRole === "CheckIn") {
-		router.push({
-			name: 'eventyaysearchcheckin'
-		})
-	} else if(processApi.selectedRole === "Badge Station") {
-		router.push({
-			name: 'eventyaycheckin'
-		})
-	}
+const errmessage = ref('')
+const showError = ref(false)
+const showScanner = ref(false)
+const showKioskPrereq = ref(false)
+const pendingRole = ref('')
+const isKioskShell = computed(() => isKioskEnvironment(route))
+const kioskLoginUrl = computed(() => buildKioskUrl(window.location.origin, '/'))
+
+const ROLE_ICONS = {
+  CheckIn: UserGroupIcon,
+  'Badge Station': PrinterIcon,
+  Exhibitor: BuildingStorefrontIcon
 }
 
-async function submitLogin() {
-  loadingStore.contentLoading()
-  showError.value = false
+const roles = computed(() => {
+  const allRoles = STATION_TYPE_DEFINITIONS.map((station) => ({
+    ...station,
+    icon: ROLE_ICONS[station.id]
+  }))
 
-  const payload = {
-    email: email.value,
-    password: password.value
+  if (!processApi.apitoken) {
+    return allRoles
   }
 
-  await authStore
-    .login(payload)
-    .then(async () => {
-      await userStore.getUserDetails()
-      router.push({
-        name: 'selectStation'
-      })
-    })
-    .catch((err) => {
-      showError.value = true
-    })
+  const allowedRoles = getAllowedRolesForProfile(processApi.securityProfile)
+  if (!allowedRoles) {
+    return allRoles
+  }
 
-  loadingStore.contentLoaded()
+  return allRoles.filter((station) => allowedRoles.includes(station.id))
+})
+
+const pendingStationLabel = computed(() => {
+  if (!pendingRole.value) {
+    return ''
+  }
+  const station = STATION_TYPE_DEFINITIONS.find((item) => item.id === pendingRole.value)
+  return station?.title || getRoleLabel(pendingRole.value)
+})
+
+const isRegisteringDevice = computed(
+  () => showScanner.value || showKioskPrereq.value
+)
+
+function redirectForRole(role) {
+  const routeName = getRoleRouteName(role)
+  if (!routeName) {
+    return
+  }
+
+  if (processApi.eventSlug) {
+    router.push({ name: routeName })
+  } else {
+    router.push({ name: 'eventyayevents' })
+  }
 }
 
-function registerDevice() {
-  processApi.setServer('eventyay.com')
-  router.push({
-    name: 'device'
-  })
+// Only checked right after a fresh device registration, so an already-registered device's
+// picked mode never gets second-guessed later — the security profile is for access clearance,
+// it should not change how an established session behaves.
+function redirectAfterRegistration(role) {
+  if (!isRoleAllowedForProfile(role, processApi.securityProfile)) {
+    router.push({ name: 'profileMismatch' })
+    return
+  }
+  redirectForRole(role)
 }
 
 function handleRoleSelection(role) {
+  pendingRole.value = role
+  showError.value = false
+  showKioskPrereq.value = false
+
+  if (!processApi.apitoken) {
+    processApi.setRole(role)
+    if (role === 'Badge Station' && !isKioskShell.value) {
+      showKioskPrereq.value = true
+      return
+    }
+    showScanner.value = true
+    return
+  }
+
+  if (!isRoleAllowedForProfile(role, processApi.securityProfile)) {
+    processApi.setRole(role)
+    router.push({ name: 'profileMismatch' })
+    return
+  }
+
+  processApi.applyStationTypeChange(role)
   processApi.setRole(role)
-  registerDevice() // Store the selected role in the store
+  redirectForRole(role)
+}
+
+function proceedToDeviceRegistration() {
+  showKioskPrereq.value = false
+  showScanner.value = true
+}
+
+function backToStationSelection() {
+  showScanner.value = false
+  showKioskPrereq.value = false
+  showManualInput.value = false
+  pendingRole.value = ''
+  showError.value = false
+  errmessage.value = ''
+  cameraStore.clearLastScan()
+  if (!processApi.apitoken) {
+    processApi.setRole('')
+  }
+}
+
+async function handleQrScanned() {
+  showError.value = false
+  loadingStore.contentLoading()
+
+  try {
+    const result = await processApi.registerDeviceByQr(cameraStore.qrCodeValue)
+    if (result.success) {
+      showScanner.value = false
+      redirectAfterRegistration(pendingRole.value || processApi.selectedRole)
+    } else if (result.error === 'unsupported_handshake') {
+      errmessage.value = 'This QR code requires a newer version of the check-in app.'
+      showError.value = true
+    } else if (result.message) {
+      errmessage.value = result.message
+      showError.value = true
+    } else {
+      errmessage.value = 'Invalid device QR code. Please scan the registration QR from your organizer dashboard.'
+      showError.value = true
+    }
+  } catch (error) {
+    console.error('Scan registration error:', error)
+    errmessage.value = 'Failed to register this device.'
+    showError.value = true
+  } finally {
+    cameraStore.clearLastScan()
+    loadingStore.contentLoaded()
+  }
+}
+
+const showManualInput = ref(false)
+const manualUrl = ref('')
+const manualToken = ref('')
+const serverUrlPlaceholder = 'https://eventyay.com'
+
+async function handleManualRegister() {
+  const urlVal = manualUrl.value.trim()
+  const tokenVal = manualToken.value.trim()
+
+  if (!urlVal || !tokenVal) {
+    errmessage.value = 'Please provide both the Server URL and Setup Token.'
+    showError.value = true
+    return
+  }
+
+  showError.value = false
+  loadingStore.contentLoading()
+
+  try {
+    const result = await processApi.registerDeviceManually(urlVal, tokenVal)
+    if (result.success) {
+      showScanner.value = false
+      showManualInput.value = false
+      redirectAfterRegistration(pendingRole.value || processApi.selectedRole)
+    } else if (result.error === 'invalid_url') {
+      errmessage.value = 'Invalid Server URL. Please enter a valid URL.'
+      showError.value = true
+    } else if (result.message) {
+      errmessage.value = result.message
+      showError.value = true
+    } else {
+      errmessage.value = 'Registration failed. Please check the Server URL and Setup Token.'
+      showError.value = true
+    }
+  } catch (error) {
+    console.error('Manual registration error:', error)
+    errmessage.value = 'Failed to register this device.'
+    showError.value = true
+  } finally {
+    loadingStore.contentLoaded()
+  }
 }
 
 onMounted(() => {
-  if (authStore.isAuthenticated) {
-    router.push({
-      name: 'selectStation'
-    })
+  if (processApi.apitoken) {
+    void processApi.syncDeviceInfo()
   }
-
-  loadingStore.contentLoaded()
 })
+
+loadingStore.contentLoaded()
 </script>
 
 <template>
-  <div class="-mt-16 flex h-screen flex-col justify-center">
-    <div class="my-auto sm:mx-auto sm:w-full sm:max-w-sm">
-      <h2 class="text-center">Select Purpose</h2>
-      <div class="mt-10 space-y-3">
-        <div>
+  <div class="page-shell flex min-h-screen items-center justify-center py-10">
+    <div class="card w-full max-w-lg p-6 sm:p-8">
+      <div class="mb-8 text-center">
+        <img v-bind="getEventyayLogoProps('full', 'mx-auto mb-4 h-10 w-auto max-w-[220px]')" />
+        <h1>Check-in</h1>
+        <p class="mt-2 text-sm text-body-muted">
+          {{
+            isRegisteringDevice
+              ? `Register this device as ${pendingStationLabel}.`
+              : 'Choose a station type to get started.'
+          }}
+        </p>
+      </div>
+
+      <Transition name="fade" mode="out-in">
+        <div v-if="showKioskPrereq" key="kiosk-prereq" class="space-y-4">
+          <div
+            v-if="pendingStationLabel"
+            class="flex items-center justify-between gap-3 rounded-lg border border-primary/20 bg-primary/5 px-3 py-2"
+          >
+            <p class="min-w-0 text-sm text-body">
+              <span class="text-body-muted">Station type</span>
+              <span class="mx-1.5 text-body-muted">·</span>
+              <span class="font-semibold">{{ pendingStationLabel }}</span>
+            </p>
+            <button
+              type="button"
+              class="shrink-0 text-xs font-semibold text-primary hover:underline focus:outline-none"
+              @click="backToStationSelection"
+            >
+              Change
+            </button>
+          </div>
+
+          <div class="rounded-xl border border-surface-border bg-surface-muted p-4 text-center">
+            <p class="text-sm font-medium text-body">Set up kiosk mode before registering</p>
+            <p class="mt-1 text-xs text-body-muted">
+              Kiosk mode enables silent badge printing. Run the command below, then register in that
+              window.
+            </p>
+          </div>
+
+          <KioskLauncherInstructions
+            :target-url="kioskLoginUrl"
+            :show-registration-steps="true"
+          />
+
           <StandardButton
             type="button"
-            text="I am an Exhibitor"
-            class="btn-primary mt-6 w-full justify-center"
-            @click="handleRoleSelection('Exhibitor')"
+            text="I'm in kiosk mode — register device"
+            variant="primary"
+            block
+            @click="proceedToDeviceRegistration"
           />
         </div>
-        <div>
-          <StandardButton
+
+        <div v-else-if="showScanner" key="scanner" class="space-y-4">
+          <div
+            v-if="pendingStationLabel"
+            class="flex items-center justify-between gap-3 rounded-lg border border-primary/20 bg-primary/5 px-3 py-2"
+          >
+            <p class="min-w-0 text-sm text-body">
+              <span class="text-body-muted">Station type</span>
+              <span class="mx-1.5 text-body-muted">·</span>
+              <span class="font-semibold">{{ pendingStationLabel }}</span>
+            </p>
+            <button
+              type="button"
+              class="shrink-0 text-xs font-semibold text-primary hover:underline focus:outline-none"
+              @click="backToStationSelection"
+            >
+              Change
+            </button>
+          </div>
+
+          <div v-if="!showManualInput" class="space-y-4">
+            <div class="rounded-xl border border-surface-border bg-surface-muted p-4 text-center">
+              <p class="text-sm font-medium text-body">Scan device registration QR</p>
+              <p class="mt-1 text-xs text-body-muted">
+                The QR code includes your server URL and setup token from the Eventyay organizer dashboard.
+              </p>
+            </div>
+            <QRCamera @scanned="handleQrScanned" />
+            <div class="text-center py-1">
+              <button
+                type="button"
+                class="text-sm font-semibold text-primary hover:underline focus:outline-none"
+                @click="showManualInput = true"
+              >
+                Or enter URL and Token manually
+              </button>
+            </div>
+          </div>
+
+          <div v-else class="space-y-4">
+            <div class="rounded-xl border border-surface-border bg-surface-muted p-4 text-center">
+              <p class="text-sm font-medium text-body">Manual Device Registration</p>
+              <p class="mt-1 text-xs text-body-muted">
+                Use the same URL as shown in the organizer device setup page (System URL), not the check-in app address.
+              </p>
+            </div>
+            <div class="space-y-3 text-left">
+              <div>
+                <label for="manual-url" class="block text-xs font-semibold text-body-muted uppercase">Server URL</label>
+                <input
+                  id="manual-url"
+                  v-model="manualUrl"
+                  type="text"
+                  :placeholder="serverUrlPlaceholder"
+                  class="mt-1 block w-full rounded-xl border border-surface-border bg-surface-muted px-3 py-2 text-sm text-body focus:border-primary focus:outline-none"
+                />
+              </div>
+              <div>
+                <label for="manual-token" class="block text-xs font-semibold text-body-muted uppercase">Setup Token</label>
+                <input
+                  id="manual-token"
+                  v-model="manualToken"
+                  type="password"
+                  placeholder="Enter your registration token"
+                  class="mt-1 block w-full rounded-xl border border-surface-border bg-surface-muted px-3 py-2 text-sm text-body focus:border-primary focus:outline-none"
+                />
+              </div>
+            </div>
+            <div class="flex gap-2">
+              <StandardButton
+                type="button"
+                text="Scan QR"
+                variant="white"
+                block
+                @click="showManualInput = false"
+              />
+              <StandardButton
+                type="button"
+                text="Register"
+                variant="primary"
+                block
+                @click="handleManualRegister"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div v-else key="roles" class="space-y-3">
+          <p class="section-title">Station type</p>
+          <button
+            v-for="role in roles"
+            :key="role.id"
             type="button"
-            text="I am a Checkin Staff"
-            class="btn-primary mt-6 w-full justify-center"
-            @click="handleRoleSelection('CheckIn')"
-          />
+            class="btn-role"
+            @click="handleRoleSelection(role.id)"
+          >
+            <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+              <component :is="role.icon" class="h-5 w-5" width="20" height="20" style="width: 20px; height: 20px;" />
+            </div>
+            <div>
+              <p class="font-semibold text-body">{{ role.buttonLabel }}</p>
+              <p class="mt-0.5 text-sm text-body-muted">{{ role.description }}</p>
+            </div>
+          </button>
         </div>
-        <div>
-          <StandardButton
-            type="button"
-            text="Badge Printing Station"
-            class="btn-primary mt-6 w-full justify-center"
-            @click="handleRoleSelection('Badge Station')"
-          />
-        </div>
+      </Transition>
+
+      <div
+        v-if="showError"
+        class="mt-5 rounded-xl border border-danger/20 bg-danger/5 px-4 py-3 text-sm text-danger"
+      >
+        {{ errmessage }}
       </div>
     </div>
   </div>

--- a/src/stores/api.js
+++ b/src/stores/api.js
@@ -4,8 +4,8 @@ import { defineStore } from 'pinia'
 export const useApiStore = defineStore('api', () => {
   const apiUrl =
     import.meta.env.MODE === 'production'
-      ? import.meta.env.VITE_PROD_API_URL
-      : import.meta.env.VITE_TEST_API_URL
+      ? (import.meta.env.VITE_PROD_API_URL || '')
+      : (import.meta.env.VITE_TEST_API_URL || '')
 
   let instance = mande(apiUrl)
 

--- a/src/stores/eventyayapi.js
+++ b/src/stores/eventyayapi.js
@@ -1,5 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
+import { redirectToUserAuth } from '@/utils/authRedirect'
+import { deviceApi, createAuthorizedDeviceApi, resolveServerUrl } from '@/utils/serverUrl'
 
 export const useEventyayApi = defineStore(
   'processApi',
@@ -14,7 +16,12 @@ export const useEventyayApi = defineStore(
     const exhiname = ref('')
     const boothname = ref('')
     const boothid = ref('')
-    const servername = ref('')
+    const limitCheckInLists = ref([])
+    const selectedCheckInListId = ref(null)
+    const isRegistering = ref(false)
+    const deviceName = ref('')
+    const gateName = ref('')
+    const securityProfile = ref('')
 
     function $reset() {
       apitoken.value = ''
@@ -27,21 +34,98 @@ export const useEventyayApi = defineStore(
       exhiname.value = ''
       boothname.value = ''
       boothid.value = ''
+      limitCheckInLists.value = []
+      selectedCheckInListId.value = null
+      isRegistering.value = false
+      deviceName.value = ''
+      gateName.value = ''
+      securityProfile.value = ''
+    }
+
+    function parseRegistrationError(error) {
+      const body = error?.body
+      if (typeof body === 'string' && body) {
+        return body
+      }
+      if (body && typeof body === 'object') {
+        if (body.token) {
+          const tokenError = Array.isArray(body.token) ? body.token[0] : body.token
+          const message = String(tokenError)
+          if (message.toLowerCase().includes('already been used')) {
+            return 'This setup code has already been used. Generate a new code in the organizer device settings and try again.'
+          }
+          return message
+        }
+        if (body.detail) {
+          return String(body.detail)
+        }
+        if (body.non_field_errors) {
+          const msg = Array.isArray(body.non_field_errors) ? body.non_field_errors[0] : body.non_field_errors
+          return String(msg)
+        }
+        const firstKey = Object.keys(body)[0]
+        if (firstKey) {
+          const val = body[firstKey]
+          const msg = Array.isArray(val) ? val[0] : val
+          if (msg) {
+            return String(msg)
+          }
+        }
+      }
+      if (!error?.response && (error?.message === 'Failed to fetch' || error?.name === 'TypeError')) {
+        return 'Could not reach the server. Open the check-in app from the same host as the device setup URL (e.g. https://dev.eventyay.com), or check network and CORS settings.'
+      }
+      return ''
     }
 
     function setApiCred(newToken, newUrl, newOrg) {
       apitoken.value = newToken
-      url.value = newUrl
+      url.value = resolveServerUrl(newUrl)
       organizer.value = newOrg
     }
 
+    function refreshServerUrl() {
+      if (url.value) {
+        url.value = resolveServerUrl(url.value)
+      }
+    }
+
+    function setDeviceInfo({ name, gate } = {}) {
+      deviceName.value = name ? String(name) : ''
+      gateName.value = gate?.name ? String(gate.name) : ''
+    }
+
+    function setSecurityProfile(profile) {
+      securityProfile.value = profile ? String(profile) : ''
+    }
+
+    function clearExhibitor() {
+      exikey.value = ''
+      exhiname.value = ''
+      boothname.value = ''
+      boothid.value = ''
+    }
+
     function setEvent(slug, name) {
+      if (eventSlug.value && eventSlug.value !== slug) {
+        clearExhibitor()
+      }
       eventSlug.value = slug
       eventname.value = name
+      selectedCheckInListId.value = null
+    }
+
+    function setLimitCheckInLists(listIds) {
+      limitCheckInLists.value = Array.isArray(listIds) ? listIds.map(Number) : []
+      selectedCheckInListId.value = null
+    }
+
+    function setSelectedCheckInListId(id) {
+      selectedCheckInListId.value = id
     }
 
     function setExhibitor(key, name, booth, bid) {
-      exikey.value = key
+      exikey.value = String(key || '').trim()
       exhiname.value = name
       boothname.value = booth
       boothid.value = bid
@@ -51,8 +135,206 @@ export const useEventyayApi = defineStore(
       selectedRole.value = role
     }
 
-    function setServer(server) {
-      servername.value = server
+    function applyStationTypeChange(nextRole) {
+      const previousRole = selectedRole.value
+      if (!nextRole || previousRole === nextRole) {
+        return
+      }
+
+      if (nextRole === 'Exhibitor') {
+        selectedCheckInListId.value = null
+        if (previousRole === 'CheckIn' || previousRole === 'Badge Station') {
+          eventSlug.value = ''
+          eventname.value = ''
+        }
+        return
+      }
+
+      clearExhibitor()
+      if (previousRole === 'Exhibitor') {
+        eventSlug.value = ''
+        eventname.value = ''
+        selectedCheckInListId.value = null
+      }
+    }
+
+    function logout({ clearRole = true, redirect = true } = {}) {
+      const preservedRole = selectedRole.value
+
+      apitoken.value = ''
+      url.value = ''
+      organizer.value = ''
+      eventSlug.value = ''
+      eventname.value = ''
+      exikey.value = ''
+      exhiname.value = ''
+      boothname.value = ''
+      boothid.value = ''
+      limitCheckInLists.value = []
+      selectedCheckInListId.value = null
+      deviceName.value = ''
+      gateName.value = ''
+      securityProfile.value = ''
+
+      if (!clearRole) {
+        selectedRole.value = preservedRole
+      } else {
+        selectedRole.value = ''
+      }
+
+      if (redirect) {
+        redirectToUserAuth()
+      }
+    }
+
+    function handleAuthError() {
+      logout({ clearRole: false })
+    }
+
+    async function initializeDevice(serverUrl, token) {
+      const cleanUrl = resolveServerUrl(serverUrl)
+      const cleanToken = String(token || '').trim()
+      if (!cleanUrl || !cleanToken) {
+        return { success: false, error: 'invalid_qr' }
+      }
+
+      try {
+        new URL(cleanUrl)
+      } catch {
+        return { success: false, error: 'invalid_url' }
+      }
+
+      const payload = {
+        token: cleanToken,
+        hardware_brand: 'Browser',
+        hardware_model: 'Web Client',
+        software_brand: 'eventyay-checkin',
+        software_version: '1.0'
+      }
+      const api = deviceApi(cleanUrl, { headers: { 'Content-Type': 'application/json' } })
+      const response = await api.post('/api/v1/device/initialize', payload)
+      if (response && response.api_token) {
+        setApiCred(response.api_token, cleanUrl, response.organizer)
+        setLimitCheckInLists(response.limit_checkin_lists || [])
+        setDeviceInfo({ name: response.name, gate: response.gate })
+        setSecurityProfile(response.security_profile)
+        return { success: true }
+      }
+      return { success: false, error: 'registration_failed' }
+    }
+
+    async function registerDeviceByQr(qrString) {
+      if (isRegistering.value) {
+        return { success: false, error: 'registration_in_progress' }
+      }
+
+      isRegistering.value = true
+      try {
+        let qrData
+        try {
+          qrData = JSON.parse(String(qrString || '').trim())
+        } catch {
+          console.error('Device registration failed: QR payload is not valid JSON')
+          return { success: false, error: 'invalid_qr' }
+        }
+
+        if (!qrData.url || !qrData.token) {
+          console.error('Device registration failed: QR payload is missing url or token')
+          return { success: false, error: 'invalid_qr' }
+        }
+
+        if (qrData.handshake_version && Number(qrData.handshake_version) > 1) {
+          return { success: false, error: 'unsupported_handshake' }
+        }
+
+        return await initializeDevice(qrData.url, qrData.token)
+      } catch (error) {
+        const message = parseRegistrationError(error)
+        console.error('Device registration failed:', error)
+        return {
+          success: false,
+          error: 'registration_failed',
+          message: message || 'Registration request was rejected by the server.'
+        }
+      } finally {
+        isRegistering.value = false
+      }
+    }
+
+    async function registerDeviceManually(inputUrl, token) {
+      if (isRegistering.value) {
+        return { success: false, error: 'registration_in_progress' }
+      }
+
+      isRegistering.value = true
+      try {
+        return await initializeDevice(inputUrl, token)
+      } catch (error) {
+        const message = parseRegistrationError(error)
+        console.error('Device registration failed:', error)
+        return {
+          success: false,
+          error: 'registration_failed',
+          message: message || 'Registration request was rejected by the server.'
+        }
+      } finally {
+        isRegistering.value = false
+      }
+    }
+
+    async function syncDeviceInfo() {
+      if (!apitoken.value || !url.value) {
+        return
+      }
+
+      refreshServerUrl()
+
+      try {
+        const api = createAuthorizedDeviceApi(url.value, apitoken.value)
+        const response = await api.post('/api/v1/device/update', {
+          hardware_brand: 'Browser',
+          hardware_model: 'Web Client',
+          software_brand: 'eventyay-checkin',
+          software_version: '1.0'
+        })
+        setDeviceInfo({ name: response.name, gate: response.gate })
+        setSecurityProfile(response.security_profile)
+      } catch {
+        // Session polling will handle revoked tokens.
+      }
+    }
+
+    async function verifySetupToken(token) {
+      const cleanToken = String(token || '').trim()
+      if (!apitoken.value || !url.value || !cleanToken) {
+        return { success: false, error: 'missing_credentials' }
+      }
+
+      refreshServerUrl()
+
+      try {
+        const api = createAuthorizedDeviceApi(url.value, apitoken.value)
+        await api.post('/api/v1/device/verify-setup-token', { token: cleanToken })
+        return { success: true }
+      } catch (error) {
+        const status = error?.response?.status
+        const body = error?.body
+        if (body?.token) {
+          const tokenError = Array.isArray(body.token) ? body.token[0] : body.token
+          return { success: false, error: 'invalid_token', message: String(tokenError) }
+        }
+        if (body?.detail) {
+          return { success: false, error: 'verification_failed', message: String(body.detail) }
+        }
+        if (status === 403) {
+          return {
+            success: false,
+            error: 'verification_failed',
+            message: 'This device is not allowed to verify the setup token. Contact the organizer.'
+          }
+        }
+        return { success: false, error: 'verification_failed' }
+      }
     }
 
     return {
@@ -62,7 +344,14 @@ export const useEventyayApi = defineStore(
       setExhibitor,
       selectedRole,
       setRole,
-      setServer,
+      applyStationTypeChange,
+      logout,
+      handleAuthError,
+      registerDeviceByQr,
+      registerDeviceManually,
+      syncDeviceInfo,
+      verifySetupToken,
+      refreshServerUrl,
       apitoken,
       url,
       organizer,
@@ -72,7 +361,16 @@ export const useEventyayApi = defineStore(
       exhiname,
       boothname,
       boothid,
-      servername
+      limitCheckInLists,
+      selectedCheckInListId,
+      setLimitCheckInLists,
+      setSelectedCheckInListId,
+      isRegistering,
+      deviceName,
+      gateName,
+      setDeviceInfo,
+      securityProfile,
+      setSecurityProfile,
     }
   },
   {

--- a/src/style.css
+++ b/src/style.css
@@ -1,31 +1,54 @@
-@import url('https://fonts.googleapis.com/css2?family=Fira+Code&family=Ubuntu&family=Merriweather&display=swap');
 @import 'tailwindcss/base';
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
 
 @layer base {
   html {
-    @apply text-body;
+    @apply text-body antialiased;
+    font-family: var(--font-sans);
+    font-size: 16px;
+  }
+
+  @media (min-width: 1440px) {
+    html {
+      font-size: 17px;
+    }
+  }
+
+  @media (min-width: 1920px) {
+    html {
+      font-size: 18px;
+    }
+  }
+
+  @media (min-width: 2560px) {
+    html {
+      font-size: 20px;
+    }
+  }
+
+  body {
+    @apply bg-surface-muted;
   }
 
   h1 {
-    @apply text-4xl font-bold leading-10 tracking-tight  sm:text-5xl;
+    @apply text-2xl font-bold tracking-tight text-body sm:text-3xl;
   }
 
   h2 {
-    @apply text-2xl font-bold leading-9 tracking-tight sm:text-3xl;
+    @apply text-xl font-semibold tracking-tight text-body sm:text-2xl;
   }
 
   h3 {
-    @apply text-base font-semibold leading-6;
+    @apply text-base font-semibold text-body;
   }
 
   button {
-    @apply rounded-md px-2.5 py-2 text-sm font-medium text-white transition disabled:cursor-not-allowed disabled:bg-secondary disabled:opacity-75 disabled:hover:bg-secondary;
+    @apply rounded-lg px-3 py-2 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-60;
   }
 
   label {
-    @apply block text-sm font-medium leading-6 text-secondary-dark;
+    @apply block text-sm font-medium text-body;
   }
 
   [type='text'],
@@ -34,51 +57,134 @@
   [type='password'],
   [type='number'],
   [type='date'],
-  [type='datetime-local'],
-  [type='month'],
   [type='search'],
   [type='tel'],
-  [type='time'],
-  [type='week'],
-  [multiple],
-  textarea,
-  select {
-    @apply rounded-md border-0 px-2.5 py-1.5 shadow-sm ring-1 ring-secondary placeholder:text-secondary focus:ring-2 focus:ring-primary sm:text-sm sm:leading-6;
+  select,
+  textarea {
+    @apply w-full rounded-lg border border-surface-border bg-white px-3 py-2.5 text-sm text-body shadow-sm placeholder:text-body-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20;
   }
 }
 
 @layer components {
   .btn-primary {
-    @apply bg-primary hover:bg-primary-dark;
+    @apply bg-primary text-white hover:bg-primary-dark focus-visible:ring-2 focus-visible:ring-primary/40;
   }
 
   .btn-secondary {
-    @apply bg-secondary hover:bg-secondary-dark;
+    @apply bg-secondary text-white hover:bg-secondary-dark;
   }
 
   .btn-success {
-    @apply bg-success hover:bg-success-dark;
+    @apply bg-success text-white hover:bg-success-dark;
   }
 
   .btn-danger {
-    @apply bg-danger hover:bg-danger-dark;
+    @apply bg-danger text-white hover:bg-danger-dark;
   }
 
   .btn-warning {
-    @apply bg-warning text-body hover:bg-warning-dark;
+    @apply bg-warning text-white hover:bg-warning-dark;
   }
 
   .btn-info {
-    @apply bg-info hover:bg-info-dark;
+    @apply bg-info text-white hover:bg-info-dark;
   }
 
   .btn-white {
-    @apply bg-white text-body hover:bg-secondary-light;
+    @apply border border-surface-border bg-white text-body hover:bg-surface-muted;
+  }
+
+  .btn-ghost {
+    @apply bg-transparent text-primary hover:bg-primary/10;
+  }
+
+  .btn-role {
+    @apply flex w-full items-start gap-4 rounded-xl border border-surface-border bg-white p-4 text-left text-body shadow-sm transition hover:border-primary/50 hover:shadow-card-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30;
+  }
+
+  .btn-role-active {
+    @apply border-primary bg-primary/5 shadow-card-hover;
+  }
+
+  .btn-server {
+    @apply flex w-full items-center justify-between rounded-xl border border-surface-border bg-white px-4 py-3 text-left text-sm transition hover:border-primary/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30;
+  }
+
+  .btn-server-active {
+    @apply border-primary bg-primary/5;
+  }
+
+  .card {
+    @apply rounded-2xl border border-surface-border bg-surface shadow-card;
+  }
+
+  .page-shell {
+    @apply mx-auto w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8 xl:max-w-7xl 2xl:max-w-[1440px];
+  }
+
+  .section-title {
+    @apply text-xs font-semibold uppercase tracking-wide text-body-muted;
   }
 }
 
 @layer utilities {
   .shadow {
-    @apply shadow-secondary;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
   }
+}
+
+.modal-enter-active,
+.modal-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.modal-enter-from,
+.modal-leave-to {
+  opacity: 0;
+}
+
+.modal-enter-active > div,
+.modal-leave-active > div {
+  transition: transform 0.2s ease;
+}
+
+.modal-enter-from > div,
+.modal-leave-to > div {
+  transform: scale(0.97);
+}
+
+.list-enter-active,
+.list-leave-active {
+  transition: all 0.25s ease;
+}
+
+.list-enter-from,
+.list-leave-to {
+  opacity: 0;
+  transform: translateY(8px);
+}
+
+.list-move {
+  transition: transform 0.25s ease;
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+  transform: translateY(4px);
+}
+
+button,
+.btn-primary,
+.btn-success,
+.btn-info,
+.btn-danger,
+.btn-warning,
+.btn-white {
+  @apply active:scale-[0.98];
 }

--- a/src/utils/authRedirect.js
+++ b/src/utils/authRedirect.js
@@ -1,0 +1,7 @@
+export function redirectToUserAuth() {
+  void import('@/router').then(({ default: router }) => {
+    if (router.currentRoute.value.name !== 'userAuth') {
+      void router.push({ name: 'userAuth' })
+    }
+  })
+}

--- a/src/utils/deviceErrors.js
+++ b/src/utils/deviceErrors.js
@@ -1,0 +1,200 @@
+export const DEVICE_PROFILE_DENIED_MESSAGE =
+  'The security profile selected for this device does not allow this functionality. Please contact your organizer to change your profile if you feel this is a mistake.'
+
+export const LEAD_SCAN_PROFILE_DENIED_MESSAGE =
+  'Lead scanning requires Full device access for this device. Ask your organizer to change the security profile in the dashboard, then register the device again.'
+
+export const DEVICE_PROFILE_DENIED_SERVER_DETAIL = 'Request denied by device security profile.'
+
+export class DeviceProfileDeniedError extends Error {
+  constructor(message = DEVICE_PROFILE_DENIED_MESSAGE) {
+    super(message)
+    this.name = 'DeviceProfileDeniedError'
+  }
+}
+
+export function getDeviceErrorStatus(error) {
+  return error?.response?.status ?? error?.status ?? 0
+}
+
+export function getDeviceErrorDetail(error) {
+  if (error instanceof DeviceProfileDeniedError) {
+    return DEVICE_PROFILE_DENIED_MESSAGE
+  }
+
+  const body = error?.body ?? error?.response?.data ?? error?.cause?.body
+  if (typeof body === 'string' && body) {
+    return body
+  }
+  if (body && typeof body === 'object') {
+    return String(body.detail || body.message || body.error || '')
+  }
+  return ''
+}
+
+function getDeviceErrorUrl(error) {
+  return String(error?.response?.url || error?.url || '')
+}
+
+export function isExhibitorApiError(error) {
+  const url = getDeviceErrorUrl(error)
+  if (url.includes('/exhibitors/')) {
+    return true
+  }
+
+  const body = error?.body ?? error?.response?.data
+  return Boolean(body && typeof body === 'object' && 'success' in body)
+}
+
+export function isDeviceProfileDeniedResponse(status, detail) {
+  return status === 403 && String(detail || '').includes('device security profile')
+}
+
+export function isDeviceAuthFailure(error) {
+  if (isExhibitorApiError(error)) {
+    return false
+  }
+
+  const status = getDeviceErrorStatus(error)
+  if (status === 401) {
+    const detail = getDeviceErrorDetail(error).toLowerCase()
+    return (
+      detail.includes('invalid token') ||
+      detail.includes('credentials were not provided') ||
+      detail.includes('device access has been revoked') ||
+      detail.includes('device has not been initialized') ||
+      detail.includes('authentication credentials') ||
+      !detail
+    )
+  }
+  if (status === 403) {
+    const detail = getDeviceErrorDetail(error).toLowerCase()
+    return (
+      detail.includes('invalid token') ||
+      detail.includes('credentials were not provided') ||
+      detail.includes('device access has been revoked') ||
+      detail.includes('authentication credentials')
+    )
+  }
+  return false
+}
+
+export function isDeviceProfileDenied(error) {
+  if (error instanceof DeviceProfileDeniedError) {
+    return true
+  }
+  return isDeviceProfileDeniedResponse(getDeviceErrorStatus(error), getDeviceErrorDetail(error))
+}
+
+export function getExhibitorErrorMessage(error, fallback = 'Lead scan request failed.') {
+  const status = getDeviceErrorStatus(error)
+  const detail = getDeviceErrorDetail(error)
+  if (status === 401) {
+    const normalized = detail.toLowerCase()
+    if (
+      normalized.includes('invalid token') ||
+      normalized.includes('device access has been revoked') ||
+      normalized.includes('device has not been initialized')
+    ) {
+      return 'Device authentication failed. Register this device again from the organizer dashboard.'
+    }
+    if (detail) {
+      return detail
+    }
+    return 'Exhibitor authentication failed. Open exhibitor sign-in and enter your exhibitor key again.'
+  }
+  if (status === 403 && isDeviceProfileDenied(error)) {
+    if (isExhibitorApiError(error)) {
+      return LEAD_SCAN_PROFILE_DENIED_MESSAGE
+    }
+    return DEVICE_PROFILE_DENIED_MESSAGE
+  }
+  return getDeviceErrorMessage(error, fallback, { hideHttpStatusText: true })
+}
+
+/**
+ * Handle exhibitor API failures without signing the device out.
+ * Returns true when the error was handled.
+ */
+export function handleExhibitorApiError(error, processApi, { onError, onProfileDenied } = {}) {
+  if (isExhibitorApiError(error) && getDeviceErrorStatus(error) === 401) {
+    onError?.(getExhibitorErrorMessage(error))
+    return true
+  }
+  if (isDeviceAuthFailure(error)) {
+    processApi?.handleAuthError?.()
+    return true
+  }
+  if (isDeviceProfileDenied(error)) {
+    onProfileDenied?.(
+      isExhibitorApiError(error) ? LEAD_SCAN_PROFILE_DENIED_MESSAGE : DEVICE_PROFILE_DENIED_MESSAGE
+    )
+    return true
+  }
+  onError?.(getExhibitorErrorMessage(error))
+  return true
+}
+
+/**
+ * Handle 401 (logout) and 403 (profile denied). Returns true when the error was handled.
+ */
+export function handleDeviceApiError(error, processApi, { onProfileDenied } = {}) {
+  if (isDeviceAuthFailure(error)) {
+    processApi?.handleAuthError?.()
+    return true
+  }
+  if (isDeviceProfileDenied(error)) {
+    onProfileDenied?.(DEVICE_PROFILE_DENIED_MESSAGE)
+    return true
+  }
+  return false
+}
+
+/** Re-throw profile denial; logout on 401. Use in store catch blocks. */
+export function raiseIfDeviceApiError(error, processApi) {
+  if (isDeviceAuthFailure(error)) {
+    processApi?.handleAuthError?.()
+    throw error
+  }
+  if (isDeviceProfileDenied(error)) {
+    throw new DeviceProfileDeniedError()
+  }
+}
+
+export function getDeviceErrorMessage(error, fallback = '', options = {}) {
+  const hideHttpStatusText = Boolean(options.hideHttpStatusText)
+  if (isDeviceProfileDenied(error) || error instanceof DeviceProfileDeniedError) {
+    return DEVICE_PROFILE_DENIED_MESSAGE
+  }
+  const body = error?.body ?? error?.response?.data ?? error?.cause?.body
+  if (body && typeof body === 'object' && body.error) {
+    return String(body.error)
+  }
+  if (body && typeof body === 'object' && !body.detail && !body.message) {
+    const parts = []
+    for (const [field, value] of Object.entries(body)) {
+      if (Array.isArray(value)) {
+        parts.push(`${field}: ${value.join(', ')}`)
+      } else if (value && typeof value === 'object') {
+        parts.push(`${field}: ${JSON.stringify(value)}`)
+      } else if (value) {
+        parts.push(`${field}: ${value}`)
+      }
+    }
+    if (parts.length) {
+      return parts.join('; ')
+    }
+  }
+  const detail = getDeviceErrorDetail(error)
+  if (detail) {
+    return detail
+  }
+  const message = error?.message || fallback
+  if (
+    hideHttpStatusText &&
+    /^(internal server error|bad request|not found|forbidden|unauthorized)$/i.test(String(message).trim())
+  ) {
+    return fallback
+  }
+  return message || fallback
+}

--- a/src/utils/deviceProfiles.js
+++ b/src/utils/deviceProfiles.js
@@ -1,0 +1,54 @@
+/**
+ * Maps backend device security profiles (see `eventyay/api/auth/devicesecurity.py`) to the
+ * station-type roles a signed-in user can pick in this app (see `STATION_TYPE_DEFINITIONS`
+ * in `@/utils/session`). Used to warn users as soon as possible when the role they picked
+ * does not match how the organizer configured the device, instead of only failing later
+ * when a specific API call gets rejected.
+ */
+
+export const SECURITY_PROFILE_LABELS = {
+  full: 'Full device access',
+  eventyay_checkin: 'Check-In Staff',
+  eventyay_checkin_online_kiosk: 'Badge Station (kiosk)'
+}
+
+// Roles allowed for each known security profile. A profile not listed here (including a
+// missing/empty value from older devices) is treated as unrestricted, matching the backend's
+// own fallback to full access for unrecognized profile identifiers.
+const ALLOWED_ROLES_BY_PROFILE = {
+  full: ['Exhibitor', 'CheckIn', 'Badge Station'],
+  eventyay_checkin: ['CheckIn', 'Badge Station'],
+  eventyay_checkin_online_kiosk: ['Badge Station']
+}
+
+// The role to suggest switching to when the current role isn't allowed for the profile.
+const SUGGESTED_ROLE_BY_PROFILE = {
+  eventyay_checkin: 'CheckIn',
+  eventyay_checkin_online_kiosk: 'Badge Station'
+}
+
+export function isKnownSecurityProfile(securityProfile) {
+  return Object.prototype.hasOwnProperty.call(ALLOWED_ROLES_BY_PROFILE, securityProfile)
+}
+
+export function getSecurityProfileLabel(securityProfile) {
+  return SECURITY_PROFILE_LABELS[securityProfile] || 'this device'
+}
+
+export function isRoleAllowedForProfile(role, securityProfile) {
+  if (!role || !isKnownSecurityProfile(securityProfile)) {
+    return true
+  }
+  return ALLOWED_ROLES_BY_PROFILE[securityProfile].includes(role)
+}
+
+export function getSuggestedRoleForProfile(securityProfile) {
+  return SUGGESTED_ROLE_BY_PROFILE[securityProfile] || null
+}
+
+export function getAllowedRolesForProfile(securityProfile) {
+  if (!isKnownSecurityProfile(securityProfile)) {
+    return null
+  }
+  return ALLOWED_ROLES_BY_PROFILE[securityProfile]
+}

--- a/src/utils/kioskLauncher.js
+++ b/src/utils/kioskLauncher.js
@@ -1,0 +1,95 @@
+export function buildKioskUrl(origin, fullPath) {
+  const basePath = fullPath.split('?')[0]
+  const params = new URLSearchParams(fullPath.includes('?') ? fullPath.split('?')[1] : '')
+  params.set('kiosk', 'true')
+  const query = params.toString()
+  return `${origin}${basePath}${query ? `?${query}` : ''}`
+}
+
+/**
+ * Kiosk mode is signaled explicitly via ?kiosk=true (included in the terminal launcher commands).
+ * Do not guess from window size — maximized browsers look like kiosk and break the navbar.
+ */
+export function isKioskEnvironment(route = null) {
+  if (typeof window === 'undefined') {
+    return false
+  }
+  if (route?.query?.kiosk === 'true') {
+    return true
+  }
+  return new URLSearchParams(window.location.search).get('kiosk') === 'true'
+}
+
+/** Silent iframe printing only works reliably in kiosk mode with kiosk-printing. */
+export function shouldUseSilentPrint(route = null) {
+  return isKioskEnvironment(route)
+}
+
+export function detectPlatform() {
+  const ua = navigator.userAgent.toLowerCase()
+  const platform = navigator.platform?.toLowerCase() || ''
+
+  if (platform.includes('mac') || ua.includes('mac os')) {
+    return 'mac'
+  }
+  if (platform.includes('win') || ua.includes('windows')) {
+    return 'windows'
+  }
+  if (platform.includes('linux') || ua.includes('linux')) {
+    return 'linux'
+  }
+  return 'unknown'
+}
+
+export function getPlatformLabel(platform = detectPlatform()) {
+  if (platform === 'mac') {
+    return 'macOS'
+  }
+  if (platform === 'windows') {
+    return 'Windows'
+  }
+  if (platform === 'linux') {
+    return 'Linux'
+  }
+  return 'Unknown'
+}
+
+export function getShellLabel(platform = detectPlatform()) {
+  if (platform === 'windows') {
+    return 'Command Prompt or PowerShell'
+  }
+  return 'Terminal'
+}
+
+export function buildChromeKioskCommand(url, platform = detectPlatform()) {
+
+  if (platform === 'windows') {
+    return `"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe" --kiosk --kiosk-printing "${url}"`
+  }
+  if (platform === 'mac') {
+    return `/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --kiosk --kiosk-printing '${url}'`
+  }
+  return `google-chrome --kiosk --kiosk-printing '${url}'`
+}
+
+export function buildFirefoxKioskCommand(url, platform = detectPlatform()) {
+  const flags = '-kiosk -pref "print.always_print_silent,true"'
+
+  if (platform === 'windows') {
+    return `"C:\\Program Files\\Mozilla Firefox\\firefox.exe" ${flags} "${url}"`
+  }
+  if (platform === 'mac') {
+    return `/Applications/Firefox.app/Contents/MacOS/firefox ${flags} '${url}'`
+  }
+  return `firefox ${flags} '${url}'`
+}
+
+export async function enterKioskShell() {
+  try {
+    if (!document.fullscreenElement && document.documentElement.requestFullscreen) {
+      await document.documentElement.requestFullscreen({ navigationUI: 'hide' })
+    }
+  } catch {
+    // Fullscreen may require a user gesture on some browsers.
+  }
+}

--- a/src/utils/serverUrl.js
+++ b/src/utils/serverUrl.js
@@ -1,0 +1,147 @@
+import { mande } from 'mande'
+import { toValue } from 'vue'
+
+export function unwrapValue(value) {
+  return toValue(value)
+}
+
+export function normalizeServerUrl(inputUrl) {
+  let cleanUrl = String(unwrapValue(inputUrl) || '').trim()
+  if (!cleanUrl) {
+    return ''
+  }
+  if (!cleanUrl.startsWith('http://') && !cleanUrl.startsWith('https://')) {
+    cleanUrl = 'https://' + cleanUrl
+  }
+  return cleanUrl.replace(/\/+$/, '')
+}
+
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]'])
+
+function isLoopbackHost(hostname) {
+  return LOOPBACK_HOSTS.has(String(hostname || '').toLowerCase())
+}
+
+function hostsMatch(left, right) {
+  return String(left || '').toLowerCase() === String(right || '').toLowerCase()
+}
+
+/**
+ * Pick an API base URL that the current browser can reach.
+ * Chrome blocks cross-origin loopback calls (e.g. 127.0.0.1:8085 -> localhost:8000).
+ * When both app and API are on loopback, use the page origin so /api is proxied (vite dev/preview).
+ * When the check-in app is served from the same host as the device QR URL (e.g. dev.eventyay.com),
+ * always use the page origin so API calls stay same-origin in production.
+ */
+export function resolveServerUrl(qrUrl) {
+  const normalized = normalizeServerUrl(qrUrl)
+  if (!normalized || typeof window === 'undefined') {
+    return normalized
+  }
+
+  const page = window.location
+
+  try {
+    const api = new URL(normalized)
+    const pageHost = page.hostname
+
+    if (api.origin === page.origin || hostsMatch(api.hostname, pageHost)) {
+      return page.origin
+    }
+
+    const pageIsLoopback = isLoopbackHost(pageHost)
+    const apiIsLoopback = isLoopbackHost(api.hostname)
+
+    // Chrome: never call :8000 directly from :8085 — use same-origin /api proxy instead.
+    if (pageIsLoopback && apiIsLoopback) {
+      return page.origin
+    }
+  } catch {
+    return normalized
+  }
+
+  return normalized
+}
+
+export function deviceApi(baseUrl, options = {}) {
+  return mande(resolveServerUrl(baseUrl), {
+    // Do not send Django session cookies — Chrome would otherwise authenticate
+    // as the control-panel user and ignore the Device token (403 on device APIs).
+    credentials: 'omit',
+    ...options
+  })
+}
+
+function toApiResourcePath(resourceUrl) {
+  const raw = String(resourceUrl || '').trim()
+  if (!raw) {
+    return ''
+  }
+  if (/^https?:\/\//i.test(raw)) {
+    try {
+      const parsed = new URL(raw)
+      return `${parsed.pathname}${parsed.search}`
+    } catch {
+      return raw
+    }
+  }
+  return raw.startsWith('/') ? raw : `/${raw}`
+}
+
+/** Build a path under /api/v1/ (always leading slash). */
+export function apiV1Path(path) {
+  const stripped = String(path || '').replace(/^\/+/, '')
+  return stripped ? `/api/v1/${stripped}` : '/api/v1/'
+}
+
+export function createAuthorizedDeviceApi(baseUrl, apitoken, extraHeaders = {}) {
+  const resolvedBaseUrl = unwrapValue(baseUrl)
+  const resolvedToken = unwrapValue(apitoken)
+  if (!resolvedBaseUrl || !resolvedToken) {
+    throw new Error('Device API credentials are not configured')
+  }
+  return deviceApi(resolvedBaseUrl, {
+    headers: {
+      Authorization: `Device ${resolvedToken}`,
+      ...extraHeaders
+    }
+  })
+}
+
+/** Lead scanner exhibitor API paths (exhibition plugin). */
+export function exhibitorApiPath(organizer, eventSlug, subpath) {
+  const org = unwrapValue(organizer)
+  const event = unwrapValue(eventSlug)
+  const suffix = String(subpath || '').replace(/^\/+/, '')
+  return `/api/v1/event/${org}/${event}/exhibitors/${suffix}`
+}
+
+export function createAuthorizedExhibitorApi(baseUrl, apitoken, exhibitorKey, extraHeaders = {}) {
+  const resolvedKey = String(unwrapValue(exhibitorKey) || '').trim()
+  if (!resolvedKey) {
+    throw new Error('Exhibitor key is not configured')
+  }
+  return createAuthorizedDeviceApi(baseUrl, apitoken, {
+    Accept: 'application/json',
+    Exhibitor: resolvedKey,
+    ...extraHeaders
+  })
+}
+
+/**
+ * Resolve API resource paths against the reachable server base.
+ * Strips absolute hosts from API responses so fetches stay same-origin (e.g. Vite proxy in dev).
+ */
+export function resolveApiResourceUrl(resourceUrl, baseUrl) {
+  const base = resolveServerUrl(baseUrl)
+  const path = toApiResourcePath(resourceUrl)
+  if (!path || !base) {
+    return ''
+  }
+  return `${base.replace(/\/+$/, '')}${path}`
+}
+
+/** Store only the path so persisted sessions do not keep unreachable absolute API hosts. */
+export function normalizeApiResourcePath(resourceUrl) {
+  return toApiResourcePath(resourceUrl)
+}

--- a/src/utils/session.js
+++ b/src/utils/session.js
@@ -1,0 +1,122 @@
+import { createAuthorizedDeviceApi } from '@/utils/serverUrl'
+import { isDeviceAuthFailure } from '@/utils/deviceErrors'
+
+const EVENTYAY_LOGO_URL = '/eventyay-logo.svg'
+const EVENTYAY_ICON_URL = '/eventyay-icon.svg'
+
+const AUTO_PRINT_KEY = 'eventyay-checkin-auto-print'
+
+const ROLE_ROUTE_MAP = {
+  Exhibitor: 'eventyayleedlogin',
+  CheckIn: 'eventyaycheckin',
+  'Badge Station': 'eventyaycheckin'
+}
+
+const ROLE_LABELS = {
+  Exhibitor: 'Lead Scanner',
+  CheckIn: 'Check-In Staff',
+  'Badge Station': 'Badge Station'
+}
+
+export const STATION_TYPE_DEFINITIONS = [
+  {
+    id: 'Exhibitor',
+    title: 'Lead Scanner',
+    buttonLabel: "I'm An Exhibitor",
+    description:
+      'Capture exhibitor leads by scanning attendee badges. Register this device with Full device access in the organizer dashboard.'
+  },
+  {
+    id: 'CheckIn',
+    title: 'Check-In Staff',
+    buttonLabel: "I'm Check-In Staff",
+    description: 'Scan tickets, search attendees, edit details, live registration, and badge printing.'
+  },
+  {
+    id: 'Badge Station',
+    title: 'Badge Station',
+    buttonLabel: "I'm Badge Station Staff",
+    description: 'Kiosk fast check-in and badge printing station. Set up kiosk mode before registering.'
+  }
+]
+
+export function getServerDisplayFromUrl(serverUrl) {
+  if (!serverUrl) {
+    return ''
+  }
+
+  try {
+    return new URL(serverUrl).host
+  } catch {
+    return String(serverUrl).replace(/^https?:\/\//, '').replace(/\/+$/, '')
+  }
+}
+
+export function getAutoPrintPreference(role) {
+  try {
+    const stored = JSON.parse(localStorage.getItem(AUTO_PRINT_KEY) || '{}')
+    if (typeof stored[role] === 'boolean') {
+      return stored[role]
+    }
+  } catch {
+    // Ignore malformed storage
+  }
+  return role === 'Badge Station'
+}
+
+export function setAutoPrintPreference(role, enabled) {
+  try {
+    const stored = JSON.parse(localStorage.getItem(AUTO_PRINT_KEY) || '{}')
+    stored[role] = enabled
+    localStorage.setItem(AUTO_PRINT_KEY, JSON.stringify(stored))
+  } catch {
+    localStorage.setItem(AUTO_PRINT_KEY, JSON.stringify({ [role]: enabled }))
+  }
+}
+
+export async function validateDeviceSession(processApi) {
+  if (!processApi.apitoken || !processApi.url) {
+    return false
+  }
+
+  try {
+    const api = createAuthorizedDeviceApi(processApi.url, processApi.apitoken)
+    const response = await api.get('/api/v1/device/session')
+    if (response && 'security_profile' in response) {
+      processApi.setSecurityProfile(response.security_profile)
+    }
+    return true
+  } catch (error) {
+    return !isDeviceAuthFailure(error)
+  }
+}
+
+export function getRoleRouteName(role) {
+  return ROLE_ROUTE_MAP[role] || null
+}
+
+export function getRoleLabel(role) {
+  return ROLE_LABELS[role] || role
+}
+
+export function getEventyayLogoProps(variant = 'full', className = '') {
+  return {
+    src: variant === 'icon' ? EVENTYAY_ICON_URL : EVENTYAY_LOGO_URL,
+    alt: 'Eventyay',
+    class: ['block rounded-md', className].filter(Boolean).join(' ')
+  }
+}
+
+export function parseQrPayload(rawValue, field) {
+  const trimmedValue = String(rawValue || '').trim()
+  if (!trimmedValue) {
+    return ''
+  }
+
+  try {
+    const parsedValue = JSON.parse(trimmedValue)
+    return parsedValue?.[field] || trimmedValue
+  } catch {
+    return trimmedValue
+  }
+}

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -1,7 +1,13 @@
+<script setup>
+import { getEventyayLogoProps } from '@/utils/session'
+</script>
+
 <template>
   <div class="flex min-h-full min-w-full flex-col bg-white pb-12 pt-16">
     <main class="mx-auto flex w-full max-w-7xl flex-grow flex-col justify-center px-6 lg:px-8">
-      <div class="flex flex-shrink-0 justify-center"></div>
+      <div class="flex flex-shrink-0 justify-center">
+        <img v-bind="getEventyayLogoProps('full', 'h-9 w-auto max-w-[200px]')" />
+      </div>
       <div class="py-16">
         <div class="text-center">
           <h1 class="font-semibold text-primary">404</h1>

--- a/src/views/UserAuth.vue
+++ b/src/views/UserAuth.vue
@@ -3,7 +3,5 @@ import LoginForm from '@/components/LoginForm.vue'
 </script>
 
 <template>
-  <div class="max-w-7xl px-2 sm:px-4 lg:px-8">
-    <LoginForm />
-  </div>
+  <LoginForm />
 </template>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,65 +1,66 @@
 /** @type {import('tailwindcss').Config} */
 
 import tailwindForms from '@tailwindcss/forms'
-import colors from 'tailwindcss/colors'
 
 export default {
-  content: [
-    "./index.html",
-    "./src/**/*.{vue,js,ts,jsx,tsx}",
-  ],
+  content: ['./index.html', './src/**/*.{vue,js,ts,jsx,tsx}'],
   theme: {
     fontFamily: {
-      sans: ['Ubuntu', 'sans-serif'],
-      serif: ['Merriweather', 'serif'],
-      mono: ['"Fira Code"', 'monospace'],
+      sans: ['var(--font-sans)'],
+      mono: ['ui-monospace', 'SFMono-Regular', 'Menlo', 'Monaco', 'Consolas', 'monospace']
     },
-    colors: {
-      // background, borders, text
-      body: {
-        light: colors.neutral[200],
-        DEFAULT: colors.neutral[900],
-        dark: colors.neutral[950],
-      },
-      // hyperlinks, focus styles, active states
-      primary: {
-        light: colors.blue[300],
-        DEFAULT: colors.blue[600],
-        dark: colors.blue[700],
-      },
-      // dividers, disabled states, placeholder text
-      secondary: {
-        light: colors.gray[200],
-        DEFAULT: colors.gray[400],
-        dark: colors.gray[800],
-      },
-      success: {
-        light: colors.green[400],
-        DEFAULT: colors.green[600],
-        dark: colors.green[800],
-      },
-      danger: {
-        light: colors.red[100],
-        DEFAULT: colors.red[600],
-        dark: colors.red[800],
-      },
-      warning: {
-        light: colors.yellow[200],
-        DEFAULT: colors.yellow[300],
-        dark: colors.yellow[400],
-      },
-      info: {
-        light: colors.indigo[200],
-        DEFAULT: colors.indigo[500],
-        dark: colors.indigo[700],
-      },
-      white: colors.white,
-      black: colors.black,
     extend: {
+      colors: {
+        body: {
+          DEFAULT: '#222222',
+          muted: '#767676',
+          light: 'rgba(0,0,0,0.6)'
+        },
+        surface: {
+          DEFAULT: '#ffffff',
+          muted: '#f8f9fa',
+          border: '#e9ecef'
+        },
+        primary: {
+          light: '#5f9cd4',
+          DEFAULT: '#2185d0',
+          dark: '#1a69a4'
+        },
+        secondary: {
+          light: '#e9ecef',
+          DEFAULT: '#6c757d',
+          dark: '#495057'
+        },
+        success: {
+          light: '#7bc492',
+          DEFAULT: '#50a167',
+          dark: '#3d7d50'
+        },
+        danger: {
+          light: '#f5c6cb',
+          DEFAULT: '#db2828',
+          dark: '#b21f2d'
+        },
+        warning: {
+          light: '#ffe8a1',
+          DEFAULT: '#ffb419',
+          dark: '#cc9014'
+        },
+        info: {
+          light: '#9ec5e8',
+          DEFAULT: '#5f9cd4',
+          dark: '#4697c9'
+        }
       },
-    },
+      boxShadow: {
+        card: '0 1px 3px rgba(0,0,0,0.08), 0 1px 2px rgba(0,0,0,0.06)',
+        'card-hover': '0 4px 12px rgba(0,0,0,0.1)'
+      },
+      borderRadius: {
+        xl: '0.75rem',
+        '2xl': '1rem'
+      }
+    }
   },
-  plugins: [
-    tailwindForms
-  ]
+  plugins: [tailwindForms]
 }


### PR DESCRIPTION
## Summary
- Setup-token device login (`LoginForm`)
- Shared helpers: `serverUrl`, `session`, `deviceErrors`, `kioskLauncher`, `deviceProfiles`
- Eventyay API store updates for device registration
- Does **not** include dependency upgrades (those are in #127)

**Merge order:** #127 → #128 → #129 → #130 → #131 → #132 → #133 → #134

After each merge, rebase remaining open PRs onto `development`.

## Test plan
- [x] `npm run build`
- [ ] Open app → Check-In Staff / Badge Station → register with system URL + setup token