### PR TITLE
fix(checkin): keep session when refreshing camera

### DIFF
--- a/src/components/Utilities/QRCamera.vue
+++ b/src/components/Utilities/QRCamera.vue
@@ -139,6 +139,23 @@ function toggleCamera() {
   }
 }
 
+async function refreshCamera() {
+  cameraStore.clearLastScan()
+  hasDetection.value = false
+
+  await updateAvailableCamera()
+
+  if (!isCameraOn.value) {
+    isCameraOn.value = true
+    cameraStore.paused = false
+  }
+
+  destroyed.value = true
+  await nextTick()
+  cameraStreamNonce.value += 1
+  destroyed.value = false
+}
+
 watch(
   () => cameraStore.isProcessing,
   (processing) => {
@@ -211,7 +228,7 @@ onUnmounted(() => {
         size="sm"
         @click="switchCamera"
       />
-      <RefreshButton />
+      <RefreshButton @refresh="refreshCamera" />
     </div>
   </div>
 </template>

--- a/src/components/Utilities/QRCamera.vue
+++ b/src/components/Utilities/QRCamera.vue
@@ -116,21 +116,6 @@ function detectedQR(detectedCodes) {
   emit('scanned')
 }
 
-/**
- * vue-qrcode-reader keeps a global async stop/start queue. Destroying and
- * recreating the stream in the same tick races the previous MediaStream release
- * and leaves a black <video> (pause-frame canvas with no picture).
- */
-const CAMERA_RESTART_DELAY_MS = 350
-
-async function remountCameraStream() {
-  destroyed.value = true
-  await nextTick()
-  await new Promise((resolve) => setTimeout(resolve, CAMERA_RESTART_DELAY_MS))
-  cameraStreamNonce.value += 1
-  destroyed.value = false
-}
-
 async function switchCamera() {
   await updateAvailableCamera()
 
@@ -139,8 +124,10 @@ async function switchCamera() {
     return
   }
 
-  cameraStore.paused = false
-  await remountCameraStream()
+  destroyed.value = true
+  await nextTick()
+  cameraStreamNonce.value += 1
+  destroyed.value = false
 }
 
 function toggleCamera() {
@@ -158,9 +145,16 @@ async function refreshCamera() {
 
   await updateAvailableCamera()
 
-  isCameraOn.value = true
-  cameraStore.paused = false
-  await remountCameraStream()
+  if (!isCameraOn.value) {
+    isCameraOn.value = true
+    cameraStore.paused = false
+  }
+
+  destroyed.value = true
+  await nextTick()
+  await new Promise((resolve) => setTimeout(resolve, 350))
+  cameraStreamNonce.value += 1
+  destroyed.value = false
 }
 
 watch(

--- a/src/components/Utilities/QRCamera.vue
+++ b/src/components/Utilities/QRCamera.vue
@@ -235,6 +235,10 @@ onUnmounted(() => {
 </template>
 
 <style scoped>
+.scanner-stream {
+  transform: scaleX(-1);
+}
+
 .scanner-stream :deep(video) {
   object-fit: cover;
 }

--- a/src/components/Utilities/QRCamera.vue
+++ b/src/components/Utilities/QRCamera.vue
@@ -116,6 +116,21 @@ function detectedQR(detectedCodes) {
   emit('scanned')
 }
 
+/**
+ * vue-qrcode-reader keeps a global async stop/start queue. Destroying and
+ * recreating the stream in the same tick races the previous MediaStream release
+ * and leaves a black <video> (pause-frame canvas with no picture).
+ */
+const CAMERA_RESTART_DELAY_MS = 350
+
+async function remountCameraStream() {
+  destroyed.value = true
+  await nextTick()
+  await new Promise((resolve) => setTimeout(resolve, CAMERA_RESTART_DELAY_MS))
+  cameraStreamNonce.value += 1
+  destroyed.value = false
+}
+
 async function switchCamera() {
   await updateAvailableCamera()
 
@@ -124,10 +139,8 @@ async function switchCamera() {
     return
   }
 
-  destroyed.value = true
-  await nextTick()
-  cameraStreamNonce.value += 1
-  destroyed.value = false
+  cameraStore.paused = false
+  await remountCameraStream()
 }
 
 function toggleCamera() {
@@ -145,15 +158,9 @@ async function refreshCamera() {
 
   await updateAvailableCamera()
 
-  if (!isCameraOn.value) {
-    isCameraOn.value = true
-    cameraStore.paused = false
-  }
-
-  destroyed.value = true
-  await nextTick()
-  cameraStreamNonce.value += 1
-  destroyed.value = false
+  isCameraOn.value = true
+  cameraStore.paused = false
+  await remountCameraStream()
 }
 
 watch(

--- a/src/components/Utilities/RefreshButton.vue
+++ b/src/components/Utilities/RefreshButton.vue
@@ -2,8 +2,10 @@
 import { ArrowPathIcon } from '@heroicons/vue/20/solid'
 import StandardButton from '@/components/Common/StandardButton.vue'
 
-function reload() {
-  window.location.reload()
+const emit = defineEmits(['refresh'])
+
+function onRefresh() {
+  emit('refresh')
 }
 </script>
 <template>
@@ -12,6 +14,6 @@ function reload() {
     :icon="ArrowPathIcon"
     variant="white"
     size="sm"
-    @click="reload"
+    @click="onRefresh"
   />
 </template>


### PR DESCRIPTION
## Summary
- The camera **Refresh** control used `window.location.reload()`, which re-ran router session validation and sent Check-In Staff back to the home/login page.
- Refresh now remounts the QR scanner stream in place (same approach as camera switch), so the device session and route stay intact.

## Test plan
- [ ] Pair as Check-In Staff, open the check-in screen, and confirm the camera works
- [ ] Click **Refresh** and confirm you stay on `/eventyaycheckin` (no redirect to home)
- [ ] Confirm the camera stream restarts and can scan again after refresh
- [ ] Confirm Turn on/off and Switch still work as before

## Summary by Sourcery

Bug Fixes:
- Fix camera refresh on the check-in screen causing a full page reload and loss of session state by handling refresh within the QR camera component.