### PR TITLE
feat(checkin): sync encrypted offline attendee data for Check-In Staff

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,12 +6,14 @@ import NotificationHolder from '@/components/Notifications/NotificationHolder.vu
 import LoadingView from '@/components/Utilities/LoadingView.vue'
 import { useLoadingStore } from '@/stores/loading'
 import { useEventyayApi } from '@/stores/eventyayapi'
+import { useOfflineSyncStore } from '@/stores/offlineSync'
 import { isKioskEnvironment } from '@/utils/kioskLauncher'
 import { validateDeviceSession } from '@/utils/session'
 
 const route = useRoute()
 const loadingStore = useLoadingStore()
 const processApi = useEventyayApi()
+const offlineSync = useOfflineSyncStore()
 const isKioskShell = computed(() => isKioskEnvironment(route))
 
 const SESSION_POLL_MS = 45000
@@ -29,6 +31,7 @@ async function pollDeviceSession() {
   }
   const isValid = await validateDeviceSession(processApi)
   if (!isValid) {
+    await offlineSync.wipe()
     processApi.handleAuthError()
   }
 }
@@ -54,10 +57,24 @@ function handleVisibilityChange() {
     if (processApi.apitoken) {
       pollDeviceSession()
       startSessionPolling()
+      if (offlineSync.enabled && offlineSync.isOnline) {
+        offlineSync.syncNow(processApi)
+      }
     }
     return
   }
   stopSessionPolling()
+}
+
+function handleOnline() {
+  offlineSync.setOnline(true)
+  if (processApi.apitoken && offlineSync.enabled) {
+    offlineSync.syncNow(processApi)
+  }
+}
+
+function handleOffline() {
+  offlineSync.setOnline(false)
 }
 
 onMounted(() => {
@@ -68,11 +85,16 @@ onMounted(() => {
   }
   startSessionPolling()
   document.addEventListener('visibilitychange', handleVisibilityChange)
+  window.addEventListener('online', handleOnline)
+  window.addEventListener('offline', handleOffline)
+  offlineSync.setOnline(navigator.onLine)
 })
 
 onBeforeUnmount(() => {
   stopSessionPolling()
   document.removeEventListener('visibilitychange', handleVisibilityChange)
+  window.removeEventListener('online', handleOnline)
+  window.removeEventListener('offline', handleOffline)
 })
 
 watch(isKioskShell, ensureNavbarLoadedForKiosk)

--- a/src/components/Eventyay/EventyayUnifiedCheckIn.vue
+++ b/src/components/Eventyay/EventyayUnifiedCheckIn.vue
@@ -28,6 +28,7 @@ import { useLiveRegistrationStore } from '@/stores/liveRegistration'
 import { useLoadingStore } from '@/stores/loading'
 import { useNotificationStore } from '@/stores/notification'
 import { useProcessEventyayCheckInStore } from '@/stores/processEventyayCheckIn'
+import { useOfflineSyncStore } from '@/stores/offlineSync'
 import { useCameraStore } from '@/stores/camera'
 import { isBadgeCustomizationUnchanged } from '@/utils/badgeCustomization'
 import { downloadPdfBlob, fetchBadgePdfWithRetry, printPdfBlob, PRINT_OUTCOME } from '@/utils/badgePdf'
@@ -1092,6 +1093,14 @@ onMounted(async () => {
       resetLiveRegistrationForm()
     }
     checkInReady.value = true
+
+    const offlineSync = useOfflineSyncStore()
+    await offlineSync.hydrate(processApi)
+    if (offlineSync.enabled && navigator.onLine) {
+      offlineSync.syncNow(processApi).catch(() => {
+        // Sync errors surface via status chip; check-in remains usable online.
+      })
+    }
   } catch (error) {
     console.error('Error loading check-in page:', error)
     notificationStore.addNotification(['Error', 'Unable to load check-in page'], 'error')

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -2,14 +2,17 @@
 import { computed, ref } from 'vue'
 import { useRoute } from 'vue-router'
 import EventyayConfigurePanel from '@/components/Eventyay/EventyayConfigurePanel.vue'
+import OfflineSyncStatus from '@/components/Utilities/OfflineSyncStatus.vue'
 import { useEventyayApi } from '@/stores/eventyayapi'
 import { useLoadingStore } from '@/stores/loading'
+import { useOfflineSyncStore } from '@/stores/offlineSync'
 import { getEventyayLogoProps, getRoleLabel } from '@/utils/session'
 import { isKioskEnvironment } from '@/utils/kioskLauncher'
 
 const route = useRoute()
 const processApi = useEventyayApi()
 const loadingStore = useLoadingStore()
+const offlineSync = useOfflineSyncStore()
 
 loadingStore.navbarLoaded()
 
@@ -53,7 +56,8 @@ const contextLabel = computed(() => {
   return parts.join(' · ')
 })
 
-function logout() {
+async function logout() {
+  await offlineSync.wipe()
   processApi.logout()
 }
 
@@ -83,6 +87,7 @@ function closeConfigure() {
       </div>
 
       <div class="flex shrink-0 items-center gap-4">
+        <OfflineSyncStatus />
         <button
           v-if="showConfigure"
           type="button"

--- a/src/components/Utilities/OfflineSyncStatus.vue
+++ b/src/components/Utilities/OfflineSyncStatus.vue
@@ -1,0 +1,38 @@
+<script setup>
+import { ArrowPathIcon } from '@heroicons/vue/20/solid'
+import { storeToRefs } from 'pinia'
+import { useOfflineSyncStore } from '@/stores/offlineSync'
+import { useEventyayApi } from '@/stores/eventyayapi'
+
+const offlineSync = useOfflineSyncStore()
+const processApi = useEventyayApi()
+const { enabled, statusLabel, isSyncing, isOnline, lastError } = storeToRefs(offlineSync)
+
+async function onSyncClick() {
+  await offlineSync.syncNow(processApi)
+}
+</script>
+
+<template>
+  <div
+    v-if="enabled"
+    class="flex items-center gap-2 text-xs text-body-muted"
+    :title="lastError || statusLabel"
+  >
+    <span
+      class="inline-flex h-2 w-2 rounded-full"
+      :class="isOnline ? 'bg-emerald-500' : 'bg-amber-500'"
+      aria-hidden="true"
+    />
+    <span class="hidden sm:inline">{{ statusLabel }}</span>
+    <button
+      type="button"
+      class="inline-flex items-center gap-1 rounded-md border border-surface-border bg-surface px-2 py-1 font-medium text-body hover:bg-surface-muted disabled:opacity-60"
+      :disabled="isSyncing || !isOnline"
+      @click="onSyncClick"
+    >
+      <ArrowPathIcon class="h-3.5 w-3.5" :class="{ 'animate-spin': isSyncing }" aria-hidden="true" />
+      Sync
+    </button>
+  </div>
+</template>

--- a/src/offline/__tests__/offlineSnapshot.spec.js
+++ b/src/offline/__tests__/offlineSnapshot.spec.js
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { decryptJson, deriveSnapshotKey, encryptJson, createDeviceSalt } from '@/offline/snapshotCrypto'
+import {
+  createEmptySnapshot,
+  mergeLayoutsIntoSnapshot,
+  mergeOrdersIntoSnapshot,
+  mergeRevokedIntoSnapshot,
+  normalizePositionFromOrder
+} from '@/offline/normalize'
+import {
+  createMemoryIndex,
+  lookupBySecret,
+  memoryIndexToSnapshot,
+  searchPositions
+} from '@/offline/memoryIndex'
+import { canUseOfflineSync } from '@/offline/syncEngine'
+import { clearSnapshotMemory, ensureDeviceSalt, saveEncryptedSnapshot, loadEncryptedSnapshot } from '@/offline/snapshotStore'
+
+describe('snapshotCrypto', () => {
+  it('round-trips JSON through AES-GCM', async () => {
+    const salt = createDeviceSalt()
+    const key = await deriveSnapshotKey('device-token-abc', salt)
+    const payload = { hello: 'world', n: 42 }
+    const envelope = await encryptJson(payload, key)
+    expect(envelope.iv).toBeTruthy()
+    expect(envelope.data).toBeTruthy()
+    await expect(decryptJson(envelope, key)).resolves.toEqual(payload)
+  })
+
+  it('fails decryption with the wrong token', async () => {
+    const salt = createDeviceSalt()
+    const key = await deriveSnapshotKey('token-a', salt)
+    const envelope = await encryptJson({ secret: 'x' }, key)
+    const otherKey = await deriveSnapshotKey('token-b', salt)
+    await expect(decryptJson(envelope, otherKey)).rejects.toBeTruthy()
+  })
+})
+
+describe('normalize + memory index', () => {
+  it('keeps custom pdf_data fields without a fixed schema', () => {
+    const record = normalizePositionFromOrder(
+      { code: 'ABC', status: 'p' },
+      {
+        id: 1,
+        secret: 'sec-1',
+        product: 9,
+        attendee_name: 'Ada',
+        pdf_data: {
+          attendee_name: 'Ada',
+          'question_42': 'Vegan',
+          images: { photo: null }
+        },
+        checkins: [{ list: 3, type: 'entry', datetime: '2030-01-01T00:00:00Z' }]
+      }
+    )
+    expect(record.pdfData.question_42).toBe('Vegan')
+    expect(record.listIds).toEqual([3])
+    expect(record.searchText).toContain('ada')
+  })
+
+  it('merges orders, layouts, and revoked secrets into lookup maps', () => {
+    const snapshot = createEmptySnapshot('org', 'evt')
+    mergeLayoutsIntoSnapshot(snapshot, [
+      {
+        id: 7,
+        name: 'Default',
+        default: true,
+        layout: '[{"type":"textarea","content":"attendee_name"}]',
+        product_assignments: [{ product: 9 }]
+      }
+    ])
+    mergeOrdersIntoSnapshot(snapshot, [
+      {
+        code: 'ABC',
+        status: 'p',
+        positions: [
+          {
+            id: 1,
+            secret: 'sec-1',
+            product: 9,
+            attendee_name: 'Ada Lovelace',
+            attendee_email: 'ada@example.test',
+            pdf_data: { attendee_name: 'Ada Lovelace' },
+            checkins: []
+          }
+        ]
+      }
+    ])
+    mergeRevokedIntoSnapshot(snapshot, [{ secret: 'revoked-1' }])
+
+    const index = createMemoryIndex(snapshot)
+    expect(lookupBySecret(index, 'sec-1').status).toBe('found')
+    expect(lookupBySecret(index, 'revoked-1').status).toBe('revoked')
+    expect(lookupBySecret(index, 'unknown').status).toBe('missing')
+    expect(searchPositions(index, 'lovelace')).toHaveLength(1)
+    expect(index.layouts.get('7').layout[0].content).toBe('attendee_name')
+
+    const roundTrip = createMemoryIndex(memoryIndexToSnapshot(index))
+    expect(roundTrip.positionsBySecret.get('sec-1').attendeeName).toBe('Ada Lovelace')
+  })
+})
+
+describe('canUseOfflineSync', () => {
+  it('allows Check-In Staff and blocks Badge Station / NoSync kiosk', () => {
+    expect(canUseOfflineSync('CheckIn', 'eventyay_checkin')).toBe(true)
+    expect(canUseOfflineSync('Badge Station', 'eventyay_checkin')).toBe(false)
+    expect(canUseOfflineSync('CheckIn', 'eventyay_checkin_online_kiosk')).toBe(false)
+    expect(canUseOfflineSync('CheckIn', 'full')).toBe(true)
+  })
+})
+
+describe('snapshotStore', () => {
+  afterEach(() => {
+    clearSnapshotMemory()
+    localStorage.clear()
+  })
+
+  it('persists and loads encrypted envelopes', async () => {
+    ensureDeviceSalt()
+    const envelope = { v: 1, iv: 'abc', data: 'def' }
+    await saveEncryptedSnapshot('org', 'evt', envelope)
+    await expect(loadEncryptedSnapshot('org', 'evt')).resolves.toEqual(envelope)
+  })
+})

--- a/src/offline/memoryIndex.js
+++ b/src/offline/memoryIndex.js
@@ -1,0 +1,135 @@
+import { buildSearchText } from '@/offline/normalize'
+
+export function createMemoryIndex(snapshot) {
+  const positionsBySecret = new Map()
+  const revokedSecrets = new Set()
+  const layouts = new Map()
+
+  Object.entries(snapshot?.positionsBySecret || {}).forEach(([secret, record]) => {
+    positionsBySecret.set(secret, record)
+  })
+  Object.keys(snapshot?.revokedSecrets || {}).forEach((secret) => {
+    if (snapshot.revokedSecrets[secret]) {
+      revokedSecrets.add(secret)
+    }
+  })
+  Object.entries(snapshot?.layouts || {}).forEach(([id, layout]) => {
+    layouts.set(String(id), layout)
+  })
+
+  return {
+    positionsBySecret,
+    revokedSecrets,
+    layouts,
+    pendingRedeems: [...(snapshot?.pendingRedeems || [])],
+    pendingRegistrations: [...(snapshot?.pendingRegistrations || [])],
+    cursors: { ...(snapshot?.cursors || {}) },
+    products: [...(snapshot?.products || [])],
+    layoutProductMap: { ...(snapshot?.layoutProductMap || {}) },
+    lastSyncedAt: snapshot?.lastSyncedAt || null,
+    organizer: snapshot?.organizer || '',
+    eventSlug: snapshot?.eventSlug || ''
+  }
+}
+
+export function memoryIndexToSnapshot(index) {
+  const positionsBySecret = {}
+  index.positionsBySecret.forEach((record, secret) => {
+    positionsBySecret[secret] = record
+  })
+  const revokedSecrets = {}
+  index.revokedSecrets.forEach((secret) => {
+    revokedSecrets[secret] = true
+  })
+  const layouts = {}
+  index.layouts.forEach((layout, id) => {
+    layouts[id] = layout
+  })
+  return {
+    version: 1,
+    organizer: index.organizer,
+    eventSlug: index.eventSlug,
+    layouts,
+    layoutProductMap: { ...index.layoutProductMap },
+    positionsBySecret,
+    revokedSecrets,
+    products: [...index.products],
+    pendingRedeems: [...index.pendingRedeems],
+    pendingRegistrations: [...index.pendingRegistrations],
+    cursors: { ...index.cursors },
+    lastSyncedAt: index.lastSyncedAt
+  }
+}
+
+export function lookupBySecret(index, secret) {
+  const key = String(secret || '').trim()
+  if (!key) {
+    return { status: 'invalid' }
+  }
+  if (index.revokedSecrets.has(key)) {
+    return { status: 'revoked' }
+  }
+  const position = index.positionsBySecret.get(key)
+  if (!position || position.canceled) {
+    return { status: 'missing' }
+  }
+  return { status: 'found', position }
+}
+
+export function searchPositions(index, query, { limit = 25 } = {}) {
+  const needle = String(query || '')
+    .trim()
+    .toLowerCase()
+  if (needle.length < 2) {
+    return []
+  }
+  const results = []
+  for (const position of index.positionsBySecret.values()) {
+    if (position.canceled) {
+      continue
+    }
+    if (index.revokedSecrets.has(position.secret)) {
+      continue
+    }
+    const haystack = position.searchText || buildSearchText(position)
+    if (haystack.includes(needle)) {
+      results.push(position)
+      if (results.length >= limit) {
+        break
+      }
+    }
+  }
+  return results
+}
+
+export function upsertPosition(index, record) {
+  if (!record?.secret) {
+    return
+  }
+  const next = {
+    ...record,
+    searchText: buildSearchText(record)
+  }
+  index.positionsBySecret.set(record.secret, next)
+}
+
+export function getDefaultLayout(index) {
+  for (const layout of index.layouts.values()) {
+    if (layout.default) {
+      return layout
+    }
+  }
+  const first = index.layouts.values().next()
+  return first.done ? null : first.value
+}
+
+export function resolveLayoutForPosition(index, position) {
+  if (position?.layoutId && index.layouts.has(String(position.layoutId))) {
+    return index.layouts.get(String(position.layoutId))
+  }
+  const mapped = index.layoutProductMap[String(position?.product)]
+  if (mapped && index.layouts.has(String(mapped))) {
+    return index.layouts.get(String(mapped))
+  }
+  return getDefaultLayout(index)
+}

--- a/src/offline/normalize.js
+++ b/src/offline/normalize.js
@@ -1,0 +1,162 @@
+export function createEmptySnapshot(organizer, eventSlug) {
+  return {
+    version: 1,
+    organizer: String(organizer || ''),
+    eventSlug: String(eventSlug || ''),
+    layouts: {},
+    layoutProductMap: {},
+    positionsBySecret: {},
+    revokedSecrets: {},
+    products: [],
+    pendingRedeems: [],
+    pendingRegistrations: [],
+    cursors: {
+      ordersModifiedSince: null,
+      revokedCreatedSince: null
+    },
+    lastSyncedAt: null
+  }
+}
+
+export function buildSearchText(position) {
+  return [position.attendeeName, position.attendeeEmail, position.company, position.orderCode, position.secret]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+}
+
+export function normalizePositionFromOrder(order, position, { listIds = [], layoutId = null } = {}) {
+  const secret = String(position?.secret || '').trim()
+  if (!secret) {
+    return null
+  }
+
+  const pdfData =
+    position?.pdf_data && typeof position.pdf_data === 'object' && !Array.isArray(position.pdf_data)
+      ? { ...position.pdf_data }
+      : {}
+
+  // Images are live URLs; keep keys but offline render may skip missing blobs.
+  if (pdfData.images && typeof pdfData.images === 'object') {
+    pdfData.images = { ...pdfData.images }
+  }
+
+  const record = {
+    id: position.id,
+    secret,
+    product: position.product ?? position.item ?? null,
+    variation: position.variation ?? null,
+    layoutId: layoutId ?? position.downloads?.find((d) => d.output === 'badge')?.layout ?? null,
+    orderCode: order?.code || position.order || '',
+    orderStatus: order?.status || position.order__status || '',
+    attendeeName: position.attendee_name || pdfData.attendee_name || '',
+    attendeeEmail: position.attendee_email || '',
+    company: position.company || pdfData.attendee_company || '',
+    jobTitle: position.job_title || pdfData.attendee_job_title || '',
+    checkins: Array.isArray(position.checkins) ? position.checkins.map(normalizeCheckin) : [],
+    listIds: listIds.length ? listIds : inferListIds(position.checkins),
+    pdfData,
+    canceled: Boolean(position.canceled)
+  }
+  record.searchText = buildSearchText(record)
+  return record
+}
+
+function normalizeCheckin(checkin) {
+  return {
+    list: checkin.list,
+    type: checkin.type || 'entry',
+    datetime: checkin.datetime || null,
+    device: checkin.device ?? null
+  }
+}
+
+function inferListIds(checkins) {
+  if (!Array.isArray(checkins)) {
+    return []
+  }
+  return [...new Set(checkins.map((c) => c.list).filter((id) => id != null))]
+}
+
+export function normalizeLayout(layout) {
+  if (!layout?.id) {
+    return null
+  }
+  let parsedLayout = layout.layout
+  if (typeof parsedLayout === 'string') {
+    try {
+      parsedLayout = JSON.parse(parsedLayout)
+    } catch {
+      parsedLayout = []
+    }
+  }
+  return {
+    id: layout.id,
+    name: layout.name || '',
+    default: Boolean(layout.default),
+    layout: Array.isArray(parsedLayout) ? parsedLayout : [],
+    size: layout.size || null,
+    background: layout.background || null,
+    askUserFields: layout.ask_user_fields || null,
+    allowCustomization: Boolean(layout.allow_customization),
+    allowBadgeEditing: Boolean(layout.allow_badge_editing),
+    productAssignments: Array.isArray(layout.product_assignments)
+      ? layout.product_assignments.map((row) => row.product).filter((id) => id != null)
+      : []
+  }
+}
+
+export function mergeOrdersIntoSnapshot(snapshot, orders) {
+  const next = snapshot
+  for (const order of orders || []) {
+    for (const position of order.positions || []) {
+      const record = normalizePositionFromOrder(order, position)
+      if (!record) {
+        continue
+      }
+      const existing = next.positionsBySecret[record.secret]
+      if (existing) {
+        record.listIds = [...new Set([...(existing.listIds || []), ...(record.listIds || [])])]
+        record.checkins = record.checkins?.length ? record.checkins : existing.checkins
+        if (!record.layoutId) {
+          record.layoutId = existing.layoutId
+        }
+        if (!Object.keys(record.pdfData || {}).length && existing.pdfData) {
+          record.pdfData = existing.pdfData
+        }
+      }
+      const productLayout = next.layoutProductMap[String(record.product)]
+      if (!record.layoutId && productLayout) {
+        record.layoutId = productLayout
+      }
+      record.searchText = buildSearchText(record)
+      next.positionsBySecret[record.secret] = record
+    }
+  }
+  return next
+}
+
+export function mergeRevokedIntoSnapshot(snapshot, revokedRows) {
+  for (const row of revokedRows || []) {
+    if (row?.secret) {
+      snapshot.revokedSecrets[String(row.secret)] = true
+    }
+  }
+  return snapshot
+}
+
+export function mergeLayoutsIntoSnapshot(snapshot, layouts) {
+  const productMap = { ...snapshot.layoutProductMap }
+  for (const layout of layouts || []) {
+    const normalized = normalizeLayout(layout)
+    if (!normalized) {
+      continue
+    }
+    snapshot.layouts[String(normalized.id)] = normalized
+    for (const productId of normalized.productAssignments) {
+      productMap[String(productId)] = normalized.id
+    }
+  }
+  snapshot.layoutProductMap = productMap
+  return snapshot
+}

--- a/src/offline/snapshotCrypto.js
+++ b/src/offline/snapshotCrypto.js
@@ -1,0 +1,79 @@
+const textEncoder = new TextEncoder()
+const textDecoder = new TextDecoder()
+
+function toBase64(buffer) {
+  const bytes =
+    buffer instanceof ArrayBuffer
+      ? new Uint8Array(buffer)
+      : buffer instanceof Uint8Array
+        ? buffer
+        : new Uint8Array(buffer)
+  let binary = ''
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  return btoa(binary)
+}
+
+function fromBase64(value) {
+  const binary = atob(value)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes
+}
+
+export function createDeviceSalt() {
+  const salt = crypto.getRandomValues(new Uint8Array(16))
+  return toBase64(salt)
+}
+
+export async function deriveSnapshotKey(apitoken, saltBase64) {
+  const token = String(apitoken || '').trim()
+  if (!token || !saltBase64) {
+    throw new Error('Missing credentials for snapshot encryption')
+  }
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw',
+    textEncoder.encode(token),
+    'PBKDF2',
+    false,
+    ['deriveKey']
+  )
+  return crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt: fromBase64(saltBase64),
+      iterations: 120000,
+      hash: 'SHA-256'
+    },
+    keyMaterial,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  )
+}
+
+export async function encryptJson(payload, key) {
+  const iv = crypto.getRandomValues(new Uint8Array(12))
+  const plaintext = textEncoder.encode(JSON.stringify(payload))
+  const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, plaintext)
+  return {
+    v: 1,
+    iv: toBase64(iv),
+    data: toBase64(ciphertext)
+  }
+}
+
+export async function decryptJson(envelope, key) {
+  if (!envelope?.iv || !envelope?.data) {
+    throw new Error('Invalid snapshot envelope')
+  }
+  const plaintext = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: fromBase64(envelope.iv) },
+    key,
+    fromBase64(envelope.data)
+  )
+  return JSON.parse(textDecoder.decode(plaintext))
+}

--- a/src/offline/snapshotStore.js
+++ b/src/offline/snapshotStore.js
@@ -1,0 +1,123 @@
+import { createDeviceSalt } from '@/offline/snapshotCrypto'
+
+const CACHE_NAME = 'eventyay-offline-snapshots-v1'
+const SALT_KEY = 'eventyay-offline-salt'
+const memoryBlobs = new Map()
+
+function snapshotKey(organizer, eventSlug) {
+  return `snapshot:${organizer}:${eventSlug}`
+}
+
+export function ensureDeviceSalt() {
+  try {
+    const existing = localStorage.getItem(SALT_KEY)
+    if (existing) {
+      return existing
+    }
+  } catch {
+    // fall through
+  }
+  const salt = createDeviceSalt()
+  try {
+    localStorage.setItem(SALT_KEY, salt)
+  } catch {
+    // Keep salt for this session via return value only if storage fails.
+  }
+  return salt
+}
+
+async function openCache() {
+  if (typeof caches === 'undefined') {
+    return null
+  }
+  try {
+    return await caches.open(CACHE_NAME)
+  } catch {
+    return null
+  }
+}
+
+export async function saveEncryptedSnapshot(organizer, eventSlug, envelope) {
+  const key = snapshotKey(organizer, eventSlug)
+  memoryBlobs.set(key, envelope)
+  const cache = await openCache()
+  if (!cache) {
+    try {
+      localStorage.setItem(key, JSON.stringify(envelope))
+    } catch {
+      // Memory-only fallback already set.
+    }
+    return
+  }
+  const body = new Blob([JSON.stringify(envelope)], { type: 'application/json' })
+  await cache.put(new Request(`https://offline.eventyay.local/${key}`), new Response(body))
+}
+
+export async function loadEncryptedSnapshot(organizer, eventSlug) {
+  const key = snapshotKey(organizer, eventSlug)
+  if (memoryBlobs.has(key)) {
+    return memoryBlobs.get(key)
+  }
+  const cache = await openCache()
+  if (cache) {
+    const match = await cache.match(new Request(`https://offline.eventyay.local/${key}`))
+    if (match) {
+      const envelope = await match.json()
+      memoryBlobs.set(key, envelope)
+      return envelope
+    }
+  }
+  try {
+    const raw = localStorage.getItem(key)
+    if (raw) {
+      const envelope = JSON.parse(raw)
+      memoryBlobs.set(key, envelope)
+      return envelope
+    }
+  } catch {
+    // ignore
+  }
+  return null
+}
+
+export async function deleteEncryptedSnapshot(organizer, eventSlug) {
+  const key = snapshotKey(organizer, eventSlug)
+  memoryBlobs.delete(key)
+  try {
+    localStorage.removeItem(key)
+  } catch {
+    // ignore
+  }
+  const cache = await openCache()
+  if (cache) {
+    await cache.delete(new Request(`https://offline.eventyay.local/${key}`))
+  }
+}
+
+export async function wipeAllEncryptedSnapshots() {
+  memoryBlobs.clear()
+  try {
+    const keys = []
+    for (let i = 0; i < localStorage.length; i += 1) {
+      const key = localStorage.key(i)
+      if (key && key.startsWith('snapshot:')) {
+        keys.push(key)
+      }
+    }
+    keys.forEach((key) => localStorage.removeItem(key))
+  } catch {
+    // ignore
+  }
+  if (typeof caches !== 'undefined') {
+    try {
+      await caches.delete(CACHE_NAME)
+    } catch {
+      // ignore
+    }
+  }
+}
+
+/** Test helper: clear in-memory blob map between specs. */
+export function clearSnapshotMemory() {
+  memoryBlobs.clear()
+}

--- a/src/offline/syncEngine.js
+++ b/src/offline/syncEngine.js
@@ -1,0 +1,176 @@
+import { resolveServerUrl } from '@/utils/serverUrl'
+import {
+  createEmptySnapshot,
+  mergeLayoutsIntoSnapshot,
+  mergeOrdersIntoSnapshot,
+  mergeRevokedIntoSnapshot
+} from '@/offline/normalize'
+import { createMemoryIndex, memoryIndexToSnapshot } from '@/offline/memoryIndex'
+import { decryptJson, deriveSnapshotKey, encryptJson } from '@/offline/snapshotCrypto'
+import {
+  ensureDeviceSalt,
+  loadEncryptedSnapshot,
+  saveEncryptedSnapshot,
+  wipeAllEncryptedSnapshots
+} from '@/offline/snapshotStore'
+
+const MAX_PAGES = 50
+
+export function canUseOfflineSync(selectedRole, securityProfile) {
+  if (selectedRole === 'Badge Station' || securityProfile === 'eventyay_checkin_online_kiosk') {
+    return false
+  }
+  return selectedRole === 'CheckIn' || securityProfile === 'eventyay_checkin' || securityProfile === 'full'
+}
+
+function joinUrl(baseUrl, path) {
+  const base = resolveServerUrl(baseUrl).replace(/\/+$/, '')
+  if (/^https?:\/\//i.test(path)) {
+    try {
+      const parsed = new URL(path)
+      return `${base}${parsed.pathname}${parsed.search}`
+    } catch {
+      return path
+    }
+  }
+  return `${base}${path.startsWith('/') ? path : `/${path}`}`
+}
+
+async function fetchJsonPage(baseUrl, apitoken, path) {
+  const response = await fetch(joinUrl(baseUrl, path), {
+    credentials: 'omit',
+    headers: {
+      Authorization: `Device ${apitoken}`,
+      Accept: 'application/json'
+    }
+  })
+  if (!response.ok) {
+    const detail = await response.text().catch(() => '')
+    const error = new Error(detail || `HTTP ${response.status}`)
+    error.status = response.status
+    throw error
+  }
+  const body = await response.json()
+  return {
+    body,
+    pageGenerated: response.headers.get('X-Page-Generated')
+  }
+}
+
+async function fetchAllPages(baseUrl, apitoken, path, { sinceParam, sinceValue, maxPages = MAX_PAGES } = {}) {
+  const results = []
+  let nextPath = path
+  let pageGenerated = null
+  let pages = 0
+
+  while (nextPath && pages < maxPages) {
+    pages += 1
+    let requestPath = nextPath
+    if (sinceParam && sinceValue && pages === 1) {
+      const url = new URL(requestPath, 'https://placeholder.local')
+      url.searchParams.set(sinceParam, sinceValue)
+      requestPath = `${url.pathname}${url.search}`
+    }
+    const { body, pageGenerated: headerCursor } = await fetchJsonPage(baseUrl, apitoken, requestPath)
+    pageGenerated = headerCursor || pageGenerated
+    const batch = Array.isArray(body) ? body : body.results || []
+    results.push(...batch)
+    if (body.next) {
+      try {
+        const nextUrl = new URL(body.next, 'https://placeholder.local')
+        nextPath = `${nextUrl.pathname}${nextUrl.search}`
+      } catch {
+        nextPath = null
+      }
+    } else {
+      nextPath = null
+    }
+  }
+
+  return { results, pageGenerated }
+}
+
+export async function loadOfflineIndex({ organizer, eventSlug, apitoken }) {
+  const envelope = await loadEncryptedSnapshot(organizer, eventSlug)
+  if (!envelope) {
+    return createMemoryIndex(createEmptySnapshot(organizer, eventSlug))
+  }
+  const salt = ensureDeviceSalt()
+  const key = await deriveSnapshotKey(apitoken, salt)
+  const snapshot = await decryptJson(envelope, key)
+  return createMemoryIndex(snapshot)
+}
+
+export async function persistOfflineIndex(index, { apitoken }) {
+  const salt = ensureDeviceSalt()
+  const key = await deriveSnapshotKey(apitoken, salt)
+  const snapshot = memoryIndexToSnapshot(index)
+  const envelope = await encryptJson(snapshot, key)
+  await saveEncryptedSnapshot(index.organizer, index.eventSlug, envelope)
+}
+
+export async function runOfflineSync({
+  url,
+  apitoken,
+  organizer,
+  eventSlug,
+  selectedRole,
+  securityProfile,
+  onProgress
+} = {}) {
+  if (!canUseOfflineSync(selectedRole, securityProfile)) {
+    return { ok: false, skipped: true, reason: 'profile_no_sync' }
+  }
+  if (!url || !apitoken || !organizer || !eventSlug) {
+    return { ok: false, error: 'missing_credentials' }
+  }
+
+  const index = await loadOfflineIndex({ organizer, eventSlug, apitoken })
+  const snapshot = memoryIndexToSnapshot(index)
+
+  onProgress?.({ phase: 'layouts' })
+  const layoutsPath = `/api/v1/organizers/${organizer}/events/${eventSlug}/badgelayouts/`
+  const { results: layouts } = await fetchAllPages(url, apitoken, layoutsPath)
+  mergeLayoutsIntoSnapshot(snapshot, layouts)
+
+  onProgress?.({ phase: 'orders' })
+  const ordersPath = `/api/v1/organizers/${organizer}/events/${eventSlug}/orders/?ordering=last_modified&pdf_data=true`
+  const { results: orders, pageGenerated: ordersCursor } = await fetchAllPages(url, apitoken, ordersPath, {
+    sinceParam: 'modified_since',
+    sinceValue: snapshot.cursors.ordersModifiedSince
+  })
+  mergeOrdersIntoSnapshot(snapshot, orders)
+  if (ordersCursor) {
+    snapshot.cursors.ordersModifiedSince = ordersCursor
+  }
+
+  onProgress?.({ phase: 'revoked' })
+  const revokedPath = `/api/v1/organizers/${organizer}/events/${eventSlug}/revokedsecrets/`
+  const { results: revoked, pageGenerated: revokedCursor } = await fetchAllPages(url, apitoken, revokedPath, {
+    sinceParam: 'created_since',
+    sinceValue: snapshot.cursors.revokedCreatedSince
+  })
+  mergeRevokedIntoSnapshot(snapshot, revoked)
+  if (revokedCursor) {
+    snapshot.cursors.revokedCreatedSince = revokedCursor
+  }
+
+  snapshot.lastSyncedAt = new Date().toISOString()
+  const nextIndex = createMemoryIndex(snapshot)
+  await persistOfflineIndex(nextIndex, { apitoken })
+
+  return {
+    ok: true,
+    index: nextIndex,
+    counts: {
+      orders: orders.length,
+      revoked: revoked.length,
+      layouts: layouts.length,
+      positions: nextIndex.positionsBySecret.size
+    }
+  }
+}
+
+export async function wipeOfflineData() {
+  await wipeAllEncryptedSnapshots()
+}

--- a/src/stores/offlineSync.js
+++ b/src/stores/offlineSync.js
@@ -1,0 +1,144 @@
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import { lookupBySecret, searchPositions } from '@/offline/memoryIndex'
+import {
+  canUseOfflineSync,
+  loadOfflineIndex,
+  runOfflineSync,
+  wipeOfflineData
+} from '@/offline/syncEngine'
+
+export const useOfflineSyncStore = defineStore('offlineSync', () => {
+  const index = ref(null)
+  const isOnline = ref(typeof navigator === 'undefined' ? true : navigator.onLine)
+  const isSyncing = ref(false)
+  const lastError = ref('')
+  const lastSyncedAt = ref(null)
+  const lastCounts = ref(null)
+  const enabled = ref(false)
+
+  const pendingCount = computed(() => {
+    if (!index.value) {
+      return 0
+    }
+    return (index.value.pendingRedeems?.length || 0) + (index.value.pendingRegistrations?.length || 0)
+  })
+
+  const statusLabel = computed(() => {
+    if (!enabled.value) {
+      return ''
+    }
+    if (isSyncing.value) {
+      return 'Syncing…'
+    }
+    if (!isOnline.value) {
+      return pendingCount.value ? `Offline · ${pendingCount.value} pending` : 'Offline'
+    }
+    if (lastSyncedAt.value) {
+      return `Synced`
+    }
+    return 'Online · not synced'
+  })
+
+  function setOnline(value) {
+    isOnline.value = Boolean(value)
+  }
+
+  async function hydrate(processApi) {
+    enabled.value =
+      Boolean(processApi?.apitoken) &&
+      canUseOfflineSync(processApi.selectedRole, processApi.securityProfile)
+    if (!enabled.value || !processApi.organizer || !processApi.eventSlug) {
+      index.value = null
+      return
+    }
+    try {
+      index.value = await loadOfflineIndex({
+        organizer: processApi.organizer,
+        eventSlug: processApi.eventSlug,
+        apitoken: processApi.apitoken
+      })
+      lastSyncedAt.value = index.value.lastSyncedAt
+    } catch {
+      index.value = null
+      lastError.value = 'Could not load offline snapshot'
+    }
+  }
+
+  async function syncNow(processApi) {
+    if (!processApi?.apitoken) {
+      return { ok: false, error: 'missing_credentials' }
+    }
+    if (!canUseOfflineSync(processApi.selectedRole, processApi.securityProfile)) {
+      enabled.value = false
+      return { ok: false, skipped: true, reason: 'profile_no_sync' }
+    }
+    enabled.value = true
+    isSyncing.value = true
+    lastError.value = ''
+    try {
+      const result = await runOfflineSync({
+        url: processApi.url,
+        apitoken: processApi.apitoken,
+        organizer: processApi.organizer,
+        eventSlug: processApi.eventSlug,
+        selectedRole: processApi.selectedRole,
+        securityProfile: processApi.securityProfile
+      })
+      if (result.ok) {
+        index.value = result.index
+        lastSyncedAt.value = result.index.lastSyncedAt
+        lastCounts.value = result.counts
+      } else if (result.error) {
+        lastError.value = result.error
+      }
+      return result
+    } catch (error) {
+      lastError.value = error?.message || 'sync_failed'
+      return { ok: false, error: lastError.value }
+    } finally {
+      isSyncing.value = false
+    }
+  }
+
+  function findBySecret(secret) {
+    if (!index.value) {
+      return { status: 'missing' }
+    }
+    return lookupBySecret(index.value, secret)
+  }
+
+  function search(query) {
+    if (!index.value) {
+      return []
+    }
+    return searchPositions(index.value, query)
+  }
+
+  async function wipe() {
+    await wipeOfflineData()
+    index.value = null
+    lastSyncedAt.value = null
+    lastCounts.value = null
+    lastError.value = ''
+    enabled.value = false
+  }
+
+  return {
+    index,
+    isOnline,
+    isSyncing,
+    lastError,
+    lastSyncedAt,
+    lastCounts,
+    enabled,
+    pendingCount,
+    statusLabel,
+    setOnline,
+    hydrate,
+    syncNow,
+    findBySecret,
+    search,
+    wipe
+  }
+})


### PR DESCRIPTION
## Summary
Encrypted offline sync foundation for Check-In Staff:
- AES-GCM snapshot in the browser (no client DB)
- Sync layouts, orders (`pdf_data`), revoked secrets into in-memory maps
- Navbar Sync chip; auto-sync on mount/reconnect; wipe on sign-out
- Badge Station / kiosk stays online-only (NoSync)

**Depends on:** https://github.com/fossasia/eventyay/pull/4856  
**Issue:** https://github.com/fossasia/eventyay-checkin/issues/103  

**Merge order:** **1/4 — merge first**, then #140 → #141 → #142 (all target `development`).

## Testing guide

### Prerequisites
- Backend running with [eventyay#4856](https://github.com/fossasia/eventyay/pull/4856) (offline sync ACL).
- Event with tickets, at least one check-in list, badges plugin on.
- Pair as **Check-In Staff** (`eventyay_checkin`), not Badge Station.

### Automated
```bash
npm ci
npm run test:unit -- --run
npm run lint
```

### Manual — Sync foundation
1. `npm run dev` and open the check-in app.
2. Pair / sign in as **Check-In Staff**, open the check-in screen.
3. Confirm navbar shows a **Sync** control / status chip.
4. Click **Sync** (online) → status becomes **Synced** (or similar) without errors.
5. In DevTools → Application:
   - Snapshot exists in Cache Storage and/or `localStorage` (encrypted blob; not plain ticket JSON).
6. Reload the page while online → status still reflects prior sync / can sync again.
7. **Sign out** → snapshot is wiped (storage cleared for that event).
8. Pair as **Badge Station** → **no** Sync chip; sync must not run.

### Checklist
- [x] Unit tests pass on this branch
- [ ] Check-In Staff Sync succeeds against backend #4856
- [ ] Encrypted snapshot persisted after sync
- [ ] Sign-out clears snapshot
- [ ] Badge Station: no Sync UI / NoSync behavior