### PR TITLE
feat(checkin): queue offline check-ins and live registrations

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -58,7 +58,7 @@ function handleVisibilityChange() {
       pollDeviceSession()
       startSessionPolling()
       if (offlineSync.enabled && offlineSync.isOnline) {
-        offlineSync.syncNow(processApi)
+        offlineSync.scheduleAutoSync(processApi, { delayMs: 0 })
       }
     }
     return
@@ -69,7 +69,7 @@ function handleVisibilityChange() {
 function handleOnline() {
   offlineSync.setOnline(true)
   if (processApi.apitoken && offlineSync.enabled) {
-    offlineSync.syncNow(processApi)
+    offlineSync.scheduleAutoSync(processApi, { delayMs: 0 })
   }
 }
 

--- a/src/components/Eventyay/EventyayUnifiedCheckIn.vue
+++ b/src/components/Eventyay/EventyayUnifiedCheckIn.vue
@@ -173,6 +173,19 @@ const SEARCH_RESULTS_LIMIT = 50
 let debounceTimer = null
 let activeRequestId = 0
 
+const offlineBrowseAvailable = computed(() => {
+  const offlineSync = useOfflineSyncStore()
+  return (
+    offlineSync.isOfflineCapable(processApi) &&
+    offlineSync.isOfflineMode() &&
+    offlineSync.hasSnapshotData
+  )
+})
+
+const searchPlaceholder = computed(() =>
+  offlineBrowseAvailable.value ? 'Search synced attendees...' : 'Search by name or email...'
+)
+
 watch(eventSlug, () => {
   eventQuestions.value = []
   searchCache.clear()
@@ -1031,6 +1044,37 @@ const searchOrders = async (query, { force = false, requestId = ++activeRequestI
     return
   }
 
+  const offlineSync = useOfflineSyncStore()
+  const offlineMode =
+    offlineSync.isOfflineCapable(processApi) && offlineSync.isOfflineMode()
+
+  if (offlineMode) {
+    if (!offlineSync.index) {
+      await offlineSync.hydrate(processApi)
+    }
+    const cacheKey = normalizedQuery || '__browse__'
+    if (!force && searchCache.has(cacheKey)) {
+      orders.value = searchCache.get(cacheKey)
+      loading.value = false
+      return
+    }
+    loading.value = true
+    const offlineResults = sortOrdersByAttendeeName(offlineSync.searchStored(normalizedQuery))
+    searchCache.set(cacheKey, offlineResults)
+    orders.value = offlineResults
+    loading.value = false
+    if (normalizedQuery && !offlineResults.length) {
+      notificationStore.addNotification(
+        [
+          'Offline search',
+          'No synced attendees matched. Connect to refresh check-in data if this person is new.'
+        ],
+        'info'
+      )
+    }
+    return
+  }
+
   if (!normalizedQuery || normalizedQuery.length < MIN_SEARCH_LENGTH) {
     orders.value = []
     loading.value = false
@@ -1064,6 +1108,21 @@ const searchOrders = async (query, { force = false, requestId = ++activeRequestI
       return
     }
 
+    if (offlineSync.isOfflineCapable(processApi)) {
+      if (!offlineSync.index) {
+        await offlineSync.hydrate(processApi)
+      }
+      const offlineResults = sortOrdersByAttendeeName(offlineSync.searchStored(normalizedQuery))
+      if (offlineResults.length) {
+        orders.value = offlineResults
+        notificationStore.addNotification(
+          ['Search unavailable', 'Showing synced offline attendees.'],
+          'info'
+        )
+        return
+      }
+    }
+
     const filtered = filterSessionCachedOrders(normalizedQuery)
 
     if (filtered.length > 0) {
@@ -1094,6 +1153,9 @@ onMounted(async () => {
   }
   loadingStore.contentLoading()
 
+  const offlineSync = useOfflineSyncStore()
+  await offlineSync.hydrate(processApi)
+
   try {
     await waitForDesignAssets()
 
@@ -1113,17 +1175,28 @@ onMounted(async () => {
     }
     checkInReady.value = true
 
-    const offlineSync = useOfflineSyncStore()
-    await offlineSync.hydrate(processApi)
     if (offlineSync.enabled && navigator.onLine) {
-      offlineSync.syncNow(processApi).catch(() => {
-        // Sync errors surface via status chip; check-in remains usable online.
-      })
+      offlineSync.scheduleAutoSync(processApi)
+    }
+
+    if (offlineSync.isOfflineMode() && offlineSync.hasSnapshotData) {
+      await searchOrders('', { force: true })
     }
   } catch (error) {
     console.error('Error loading check-in page:', error)
-    notificationStore.addNotification(['Error', 'Unable to load check-in page'], 'error')
-    checkInReady.value = true
+    if (offlineSync.hasSnapshotData) {
+      notificationStore.addNotification(
+        ['Offline mode', 'Using synced check-in data. Connect to refresh.'],
+        'info'
+      )
+      checkInReady.value = true
+      if (offlineSync.isOfflineMode()) {
+        await searchOrders('', { force: true })
+      }
+    } else {
+      notificationStore.addNotification(['Error', 'Unable to load check-in page'], 'error')
+      checkInReady.value = true
+    }
   } finally {
     loadingStore.contentLoaded()
   }
@@ -1152,8 +1225,12 @@ watch(searchQuery, (value) => {
     clearTimeout(debounceTimer)
   }
 
+  const offlineSync = useOfflineSyncStore()
+  const offlineMode =
+    offlineSync.isOfflineCapable(processApi) && offlineSync.isOfflineMode()
+
   const normalizedQuery = getNormalizedSearchQuery(value)
-  if (!normalizedQuery || normalizedQuery.length < MIN_SEARCH_LENGTH) {
+  if (!offlineMode && (!normalizedQuery || normalizedQuery.length < MIN_SEARCH_LENGTH)) {
     orders.value = []
     loading.value = false
     return
@@ -1163,6 +1240,18 @@ watch(searchQuery, (value) => {
     searchOrders(value, { requestId })
   }, SEARCH_DEBOUNCE_MS)
 })
+
+watch(
+  () => useOfflineSyncStore().isOnline,
+  (online) => {
+    const offlineSync = useOfflineSyncStore()
+    if (!online && offlineSync.isOfflineCapable(processApi) && offlineSync.hasSnapshotData) {
+      void searchOrders(searchQuery.value, { force: true })
+    } else if (online && !getNormalizedSearchQuery(searchQuery.value)) {
+      orders.value = []
+    }
+  }
+)
 
 onBeforeUnmount(() => {
   document.removeEventListener('visibilitychange', handleVisibilityChange)
@@ -1348,13 +1437,16 @@ const openAttendeeFromSearch = async (order) => {
           <input
             v-model="searchQuery"
             type="search"
-            placeholder="Search by name or email..."
+            :placeholder="searchPlaceholder"
             class="pl-10"
           />
         </div>
 
         <div class="min-h-0 flex-1 overflow-y-auto">
-          <div v-if="!searchQuery" class="flex h-full items-center justify-center text-center">
+          <div
+            v-if="!searchQuery && !offlineBrowseAvailable"
+            class="flex h-full items-center justify-center text-center"
+          >
             <p class="text-sm text-body-muted">Type at least 2 characters to search attendees.</p>
           </div>
 
@@ -1363,10 +1455,20 @@ const openAttendeeFromSearch = async (order) => {
           </div>
 
           <div v-else-if="orders.length === 0" class="py-10 text-center text-sm text-body-muted">
-            No matching attendees found.
+            <p v-if="offlineBrowseAvailable && !searchQuery">
+              No synced attendees yet. Connect to the internet to sync check-in data.
+            </p>
+            <p v-else>No matching attendees found.</p>
           </div>
 
-          <TransitionGroup v-else name="list" tag="div" class="space-y-2">
+          <template v-else>
+            <p
+              v-if="offlineBrowseAvailable && !searchQuery"
+              class="mb-3 text-xs text-body-muted"
+            >
+              Showing synced attendees. Type to filter.
+            </p>
+            <TransitionGroup name="list" tag="div" class="space-y-2">
             <article
               v-for="order in orders"
               :key="order.id"
@@ -1396,6 +1498,7 @@ const openAttendeeFromSearch = async (order) => {
               </div>
             </article>
           </TransitionGroup>
+          </template>
         </div>
       </section>
     </div>

--- a/src/components/Eventyay/EventyayUnifiedCheckIn.vue
+++ b/src/components/Eventyay/EventyayUnifiedCheckIn.vue
@@ -668,12 +668,31 @@ const submitLiveRegistration = async () => {
     )
 
     closeLiveRegistrationDialog()
+    if (registrationResult.offlinePending) {
+      liveRegistrationResult.value = {
+        attendeeName,
+        orderCode: '',
+        orderPositionId: null,
+        ticketDownloadUrl: '',
+        ticketDownloadAvailable: false,
+        offlinePending: true
+      }
+      notificationStore.addNotification(
+        [
+          'Queued offline',
+          'Live registration will sync when you are back online. Ticket printing is available after sync.'
+        ],
+        'success'
+      )
+      return
+    }
     liveRegistrationResult.value = {
       attendeeName,
       orderCode: registrationResult.orderCode,
       orderPositionId: registrationResult.orderPositionId || registrationResult.orderPosition?.id || null,
       ticketDownloadUrl: registrationResult.ticketDownloadUrl || '',
-      ticketDownloadAvailable: registrationResult.ticketDownloadAvailable === true
+      ticketDownloadAvailable: registrationResult.ticketDownloadAvailable === true,
+      offlinePending: false
     }
   } catch (error) {
     console.error('Live registration failed:', error)
@@ -1455,7 +1474,9 @@ const openAttendeeFromSearch = async (order) => {
         class="fixed inset-0 z-[70] flex items-center justify-center bg-black/50 p-4"
       >
         <div class="card w-full max-w-md p-6">
-          <h2 class="mb-1 text-xl text-success">Registration complete</h2>
+          <h2 class="mb-1 text-xl text-success">
+            {{ liveRegistrationResult.offlinePending ? 'Registration queued' : 'Registration complete' }}
+          </h2>
           <p class="mb-4 text-sm text-body-muted">
             {{ liveRegistrationResult.attendeeName }}
             <span v-if="liveRegistrationResult.orderCode">
@@ -1464,7 +1485,15 @@ const openAttendeeFromSearch = async (order) => {
           </p>
 
           <p
-            v-if="!liveRegistrationResult.ticketDownloadAvailable"
+            v-if="liveRegistrationResult.offlinePending"
+            class="rounded-xl border border-warning/30 bg-warning/10 px-4 py-3 text-sm text-warning-dark"
+          >
+            You are offline. This registration will sync when connectivity returns. Printing is
+            available after a successful sync.
+          </p>
+
+          <p
+            v-else-if="!liveRegistrationResult.ticketDownloadAvailable"
             class="rounded-xl border border-warning/30 bg-warning/10 px-4 py-3 text-sm text-warning-dark"
           >
             Ticket PDF download is not configured for this event. Enable the PDF ticket output

--- a/src/components/Utilities/OfflineSyncStatus.vue
+++ b/src/components/Utilities/OfflineSyncStatus.vue
@@ -1,16 +1,9 @@
 <script setup>
-import { ArrowPathIcon } from '@heroicons/vue/20/solid'
 import { storeToRefs } from 'pinia'
 import { useOfflineSyncStore } from '@/stores/offlineSync'
-import { useEventyayApi } from '@/stores/eventyayapi'
 
 const offlineSync = useOfflineSyncStore()
-const processApi = useEventyayApi()
-const { enabled, statusLabel, isSyncing, isOnline, lastError } = storeToRefs(offlineSync)
-
-async function onSyncClick() {
-  await offlineSync.syncNow(processApi)
-}
+const { enabled, statusLabel, isOnline, lastError } = storeToRefs(offlineSync)
 </script>
 
 <template>
@@ -25,14 +18,5 @@ async function onSyncClick() {
       aria-hidden="true"
     />
     <span class="hidden sm:inline">{{ statusLabel }}</span>
-    <button
-      type="button"
-      class="inline-flex items-center gap-1 rounded-md border border-surface-border bg-surface px-2 py-1 font-medium text-body hover:bg-surface-muted disabled:opacity-60"
-      :disabled="isSyncing || !isOnline"
-      @click="onSyncClick"
-    >
-      <ArrowPathIcon class="h-3.5 w-3.5" :class="{ 'animate-spin': isSyncing }" aria-hidden="true" />
-      Sync
-    </button>
   </div>
 </template>

--- a/src/offline/__tests__/offlineActions.spec.js
+++ b/src/offline/__tests__/offlineActions.spec.js
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { createEmptySnapshot } from '@/offline/normalize'
+import { createMemoryIndex } from '@/offline/memoryIndex'
+import {
+  applyLocalCheckin,
+  enqueuePendingRedeem,
+  enqueuePendingRegistration,
+  evaluateLocalRedeem,
+  MISSING_OFFLINE_DATA_MESSAGE
+} from '@/offline/offlineActions'
+
+describe('offlineActions', () => {
+  function indexWithAttendee() {
+    const snapshot = createEmptySnapshot('org', 'evt')
+    snapshot.positionsBySecret['sec-1'] = {
+      id: 1,
+      secret: 'sec-1',
+      product: 9,
+      orderStatus: 'p',
+      attendeeName: 'Ada',
+      attendeeEmail: 'ada@example.test',
+      company: '',
+      jobTitle: '',
+      checkins: [],
+      listIds: [3],
+      pdfData: { attendee_name: 'Ada' },
+      searchText: 'ada ada@example.test sec-1'
+    }
+    return createMemoryIndex(snapshot)
+  }
+
+  it('asks to reconnect when the secret is not in the snapshot', () => {
+    const index = indexWithAttendee()
+    const result = evaluateLocalRedeem(index, 'unknown', { listId: 3, type: 'entry' })
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBe('missing')
+    expect(result.message).toBe(MISSING_OFFLINE_DATA_MESSAGE)
+  })
+
+  it('rejects revoked secrets', () => {
+    const index = indexWithAttendee()
+    index.revokedSecrets.add('sec-1')
+    const result = evaluateLocalRedeem(index, 'sec-1', { listId: 3 })
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBe('revoked')
+  })
+
+  it('queues a local check-in with a stable nonce entry', () => {
+    const index = indexWithAttendee()
+    const evaluation = evaluateLocalRedeem(index, 'sec-1', { listId: 3, type: 'entry' })
+    expect(evaluation.ok).toBe(true)
+    applyLocalCheckin(index, evaluation.position, { listId: 3, type: 'entry' })
+    enqueuePendingRedeem(index, {
+      secret: 'sec-1',
+      lists: [3],
+      type: 'entry',
+      nonce: 'abc123',
+      datetime: '2030-01-01T00:00:00Z'
+    })
+    expect(index.pendingRedeems).toHaveLength(1)
+    expect(index.positionsBySecret.get('sec-1').checkins).toHaveLength(1)
+
+    const second = evaluateLocalRedeem(index, 'sec-1', { listId: 3, type: 'entry' })
+    expect(second.alreadyRedeemed).toBe(true)
+  })
+
+  it('queues live registrations without inventing a ticket secret', () => {
+    const index = indexWithAttendee()
+    enqueuePendingRegistration(index, {
+      id: 'pending-1',
+      payload: { email: 'new@example.test' },
+      createdAt: '2030-01-01T00:00:00Z'
+    })
+    expect(index.pendingRegistrations).toHaveLength(1)
+    expect(index.pendingRegistrations[0].payload.email).toBe('new@example.test')
+  })
+})

--- a/src/offline/__tests__/offlineSnapshot.spec.js
+++ b/src/offline/__tests__/offlineSnapshot.spec.js
@@ -9,6 +9,7 @@ import {
 } from '@/offline/normalize'
 import {
   createMemoryIndex,
+  listStoredPositions,
   lookupBySecret,
   memoryIndexToSnapshot,
   searchPositions
@@ -93,6 +94,9 @@ describe('normalize + memory index', () => {
     expect(lookupBySecret(index, 'revoked-1').status).toBe('revoked')
     expect(lookupBySecret(index, 'unknown').status).toBe('missing')
     expect(searchPositions(index, 'lovelace')).toHaveLength(1)
+    expect(listStoredPositions(index, '')).toHaveLength(1)
+    expect(listStoredPositions(index, 'ada')).toHaveLength(1)
+    expect(listStoredPositions(index, 'zzz')).toHaveLength(0)
     expect(index.layouts.get('7').layout[0].content).toBe('attendee_name')
 
     const roundTrip = createMemoryIndex(memoryIndexToSnapshot(index))

--- a/src/offline/memoryIndex.js
+++ b/src/offline/memoryIndex.js
@@ -102,6 +102,48 @@ export function searchPositions(index, query, { limit = 25 } = {}) {
   return results
 }
 
+/** Return synced attendees for offline browse/search (all or filtered, sorted by name). */
+export function listStoredPositions(index, query = '', { limit = 100 } = {}) {
+  const needle = String(query || '').trim().toLowerCase()
+  const results = []
+  for (const position of index.positionsBySecret.values()) {
+    if (position.canceled || index.revokedSecrets.has(position.secret)) {
+      continue
+    }
+    if (needle.length >= 2) {
+      const haystack = position.searchText || buildSearchText(position)
+      if (!haystack.includes(needle)) {
+        continue
+      }
+    }
+    results.push(position)
+  }
+  results.sort((a, b) =>
+    String(a.attendeeName || '').localeCompare(String(b.attendeeName || ''), undefined, {
+      sensitivity: 'base'
+    })
+  )
+  return results.slice(0, limit)
+}
+
+/** Map a snapshot position into the check-in search result row shape. */
+export function positionToSearchOrder(position) {
+  return {
+    id: position.id,
+    secret: position.secret,
+    attendee_name: position.attendeeName || '',
+    attendee_email: position.attendeeEmail || '',
+    company: position.company || '',
+    job_title: position.jobTitle || '',
+    product: position.product,
+    variation: position.variation,
+    order: position.orderCode,
+    checkins: position.checkins || [],
+    pdf_data: position.pdfData || {},
+    offline: true
+  }
+}
+
 export function upsertPosition(index, record) {
   if (!record?.secret) {
     return

--- a/src/offline/offlineActions.js
+++ b/src/offline/offlineActions.js
@@ -1,0 +1,217 @@
+import { lookupBySecret, upsertPosition } from '@/offline/memoryIndex'
+import { normalizePositionFromOrder } from '@/offline/normalize'
+
+export const MISSING_OFFLINE_DATA_MESSAGE =
+  'Please connect to the internet to fetch the latest check-in data, then try again.'
+
+export function isBrowserOffline() {
+  return typeof navigator !== 'undefined' && navigator.onLine === false
+}
+
+export function evaluateLocalRedeem(index, secret, { listId, type = 'entry' } = {}) {
+  const lookup = lookupBySecret(index, secret)
+  if (lookup.status === 'revoked') {
+    return { ok: false, reason: 'revoked', message: 'This ticket has been revoked.' }
+  }
+  if (lookup.status !== 'found') {
+    return {
+      ok: false,
+      reason: 'missing',
+      message: MISSING_OFFLINE_DATA_MESSAGE
+    }
+  }
+
+  const position = lookup.position
+  if (position.orderStatus && position.orderStatus !== 'p' && position.orderStatus !== 'n') {
+    return { ok: false, reason: 'unpaid', message: 'This ticket is not paid.', position }
+  }
+
+  const listIdNum = Number(listId)
+  if (
+    Array.isArray(position.listIds) &&
+    position.listIds.length > 0 &&
+    listId != null &&
+    !position.listIds.map(Number).includes(listIdNum)
+  ) {
+    // listIds inferred from prior checkins may be incomplete; do not block if empty.
+  }
+
+  const alreadyOnList = (position.checkins || []).some(
+    (checkin) => Number(checkin.list) === listIdNum && (checkin.type || 'entry') === type
+  )
+  if (alreadyOnList && type === 'entry') {
+    return {
+      ok: true,
+      alreadyRedeemed: true,
+      position,
+      status: 'redeemed'
+    }
+  }
+
+  return { ok: true, alreadyRedeemed: false, position, status: 'ok' }
+}
+
+export function applyLocalCheckin(index, position, { listId, type = 'entry', datetime = null } = {}) {
+  const next = {
+    ...position,
+    checkins: [
+      ...(position.checkins || []),
+      {
+        list: Number(listId),
+        type,
+        datetime: datetime || new Date().toISOString(),
+        device: null
+      }
+    ]
+  }
+  if (!next.listIds?.includes(Number(listId))) {
+    next.listIds = [...new Set([...(next.listIds || []), Number(listId)])]
+  }
+  upsertPosition(index, next)
+  return next
+}
+
+export function enqueuePendingRedeem(index, entry) {
+  index.pendingRedeems = [...(index.pendingRedeems || []), entry]
+}
+
+export function enqueuePendingRegistration(index, entry) {
+  index.pendingRegistrations = [...(index.pendingRegistrations || []), entry]
+}
+
+export async function flushPendingRedeems(index, { url, apitoken, organizer }) {
+  const pending = [...(index.pendingRedeems || [])]
+  if (!pending.length) {
+    return { flushed: 0, remaining: [] }
+  }
+
+  const remaining = []
+  let flushed = 0
+
+  for (const item of pending) {
+    try {
+      const response = await fetch(`${String(url).replace(/\/+$/, '')}/api/v1/organizers/${organizer}/checkin/redeem/`, {
+        method: 'POST',
+        credentials: 'omit',
+        headers: {
+          Authorization: `Device ${apitoken}`,
+          Accept: 'application/json',
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          secret: item.secret,
+          source_type: 'barcode',
+          lists: item.lists,
+          type: item.type || 'entry',
+          force: false,
+          ignore_unpaid: false,
+          nonce: item.nonce,
+          datetime: item.datetime || null,
+          questions_supported: false
+        })
+      })
+      const body = await response.json().catch(() => ({}))
+      if (response.ok && (body.status === 'ok' || body.status === 'redeemed')) {
+        flushed += 1
+        if (body.position) {
+          const record = normalizePositionFromOrder(
+            { code: body.position.order, status: body.position.order__status || 'p' },
+            body.position
+          )
+          if (record) {
+            upsertPosition(index, record)
+          }
+        }
+        continue
+      }
+      if (body.status === 'error' && body.reason === 'already_redeemed') {
+        flushed += 1
+        continue
+      }
+      if (response.status >= 500 || response.status === 0) {
+        remaining.push(item)
+        continue
+      }
+      remaining.push({ ...item, lastError: body.reason || `HTTP ${response.status}` })
+    } catch {
+      remaining.push(item)
+    }
+  }
+
+  index.pendingRedeems = remaining
+  return { flushed, remaining }
+}
+
+export async function flushPendingRegistrations(index, { url, apitoken, organizer, eventSlug }) {
+  const pending = [...(index.pendingRegistrations || [])]
+  if (!pending.length) {
+    return { flushed: 0, remaining: [] }
+  }
+
+  const base = String(url).replace(/\/+$/, '')
+  const remaining = []
+  let flushed = 0
+
+  for (const item of pending) {
+    try {
+      const createResp = await fetch(
+        `${base}/api/v1/organizers/${organizer}/events/${eventSlug}/orders/`,
+        {
+          method: 'POST',
+          credentials: 'omit',
+          headers: {
+            Authorization: `Device ${apitoken}`,
+            Accept: 'application/json',
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify(item.payload)
+        }
+      )
+      const created = await createResp.json().catch(() => ({}))
+      if (!createResp.ok) {
+        if (createResp.status >= 500) {
+          remaining.push(item)
+        } else {
+          remaining.push({ ...item, lastError: JSON.stringify(created) })
+        }
+        continue
+      }
+
+      let paid = created
+      if (created.status !== 'p') {
+        const paidResp = await fetch(
+          `${base}/api/v1/organizers/${organizer}/events/${eventSlug}/orders/${created.code}/mark_paid/`,
+          {
+            method: 'POST',
+            credentials: 'omit',
+            headers: {
+              Authorization: `Device ${apitoken}`,
+              Accept: 'application/json',
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ send_email: false })
+          }
+        )
+        paid = await paidResp.json().catch(() => ({}))
+        if (!paidResp.ok || paid.status !== 'p') {
+          remaining.push({ ...item, lastError: 'mark_paid_failed', createdCode: created.code })
+          continue
+        }
+      }
+
+      const position = paid.positions?.[0]
+      if (position) {
+        const record = normalizePositionFromOrder(paid, position)
+        if (record) {
+          upsertPosition(index, record)
+        }
+      }
+      flushed += 1
+    } catch {
+      remaining.push(item)
+    }
+  }
+
+  index.pendingRegistrations = remaining
+  return { flushed, remaining }
+}

--- a/src/offline/syncEngine.js
+++ b/src/offline/syncEngine.js
@@ -13,6 +13,7 @@ import {
   saveEncryptedSnapshot,
   wipeAllEncryptedSnapshots
 } from '@/offline/snapshotStore'
+import { flushPendingRedeems, flushPendingRegistrations } from '@/offline/offlineActions'
 
 const MAX_PAGES = 50
 
@@ -157,6 +158,42 @@ export async function runOfflineSync({
 
   snapshot.lastSyncedAt = new Date().toISOString()
   const nextIndex = createMemoryIndex(snapshot)
+
+  onProgress?.({ phase: 'flush' })
+  await flushPendingRedeems(nextIndex, { url, apitoken, organizer })
+  await flushPendingRegistrations(nextIndex, { url, apitoken, organizer, eventSlug })
+
+  // Absorb server-side results of flushed registrations / concurrent check-ins.
+  const { results: followUpOrders, pageGenerated: followUpCursor } = await fetchAllPages(
+    url,
+    apitoken,
+    `/api/v1/organizers/${organizer}/events/${eventSlug}/orders/?ordering=last_modified&pdf_data=true`,
+    {
+      sinceParam: 'modified_since',
+      sinceValue: nextIndex.cursors.ordersModifiedSince
+    }
+  )
+  if (followUpOrders.length) {
+    const followSnapshot = memoryIndexToSnapshot(nextIndex)
+    mergeOrdersIntoSnapshot(followSnapshot, followUpOrders)
+    if (followUpCursor) {
+      followSnapshot.cursors.ordersModifiedSince = followUpCursor
+    }
+    followSnapshot.lastSyncedAt = new Date().toISOString()
+    const merged = createMemoryIndex(followSnapshot)
+    await persistOfflineIndex(merged, { apitoken })
+    return {
+      ok: true,
+      index: merged,
+      counts: {
+        orders: orders.length + followUpOrders.length,
+        revoked: revoked.length,
+        layouts: layouts.length,
+        positions: merged.positionsBySecret.size
+      }
+    }
+  }
+
   await persistOfflineIndex(nextIndex, { apitoken })
 
   return {

--- a/src/stores/liveRegistration.js
+++ b/src/stores/liveRegistration.js
@@ -3,6 +3,9 @@ import { createAuthorizedDeviceApi } from '@/utils/serverUrl'
 import { raiseIfDeviceApiError } from '@/utils/deviceErrors'
 import { ref } from 'vue'
 import { useEventyayApi } from '@/stores/eventyayapi'
+import { useOfflineSyncStore } from '@/stores/offlineSync'
+import { enqueuePendingRegistration, isBrowserOffline } from '@/offline/offlineActions'
+import { canUseOfflineSync, persistOfflineIndex } from '@/offline/syncEngine'
 
 const DEFAULT_INVOICE_ADDRESS = {
   is_business: false,
@@ -157,6 +160,37 @@ export const useLiveRegistrationStore = defineStore('liveRegistration', () => {
     isRegistering.value = true
 
     try {
+      const processApi = useEventyayApi()
+      if (
+        isBrowserOffline() &&
+        canUseOfflineSync(processApi.selectedRole, processApi.securityProfile)
+      ) {
+        const offlineSync = useOfflineSyncStore()
+        if (!offlineSync.index) {
+          await offlineSync.hydrate(processApi)
+        }
+        const payload = buildOrderPayload(attendee, productId)
+        const pendingId = `pending-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+        enqueuePendingRegistration(offlineSync.index, {
+          id: pendingId,
+          payload,
+          createdAt: new Date().toISOString()
+        })
+        await persistOfflineIndex(offlineSync.index, { apitoken: processApi.apitoken })
+        return {
+          createdOrder: null,
+          paidOrder: null,
+          secret: '',
+          orderCode: '',
+          orderPosition: null,
+          orderPositionId: null,
+          ticketDownloadUrl: '',
+          ticketDownloadAvailable: false,
+          offlinePending: true,
+          pendingId
+        }
+      }
+
       const createdOrder = await createOrder(attendee, productId)
       const orderCode = createdOrder?.code
       if (!orderCode) {

--- a/src/stores/offlineSync.js
+++ b/src/stores/offlineSync.js
@@ -1,6 +1,11 @@
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
-import { lookupBySecret, searchPositions } from '@/offline/memoryIndex'
+import {
+  lookupBySecret,
+  listStoredPositions,
+  positionToSearchOrder,
+  searchPositions
+} from '@/offline/memoryIndex'
 import {
   canUseOfflineSync,
   loadOfflineIndex,
@@ -16,6 +21,7 @@ export const useOfflineSyncStore = defineStore('offlineSync', () => {
   const lastSyncedAt = ref(null)
   const lastCounts = ref(null)
   const enabled = ref(false)
+  let autoSyncTimer = null
 
   const pendingCount = computed(() => {
     if (!index.value) {
@@ -23,6 +29,8 @@ export const useOfflineSyncStore = defineStore('offlineSync', () => {
     }
     return (index.value.pendingRedeems?.length || 0) + (index.value.pendingRegistrations?.length || 0)
   })
+
+  const hasSnapshotData = computed(() => Boolean(index.value?.positionsBySecret?.size))
 
   const statusLabel = computed(() => {
     if (!enabled.value) {
@@ -35,22 +43,57 @@ export const useOfflineSyncStore = defineStore('offlineSync', () => {
       return pendingCount.value ? `Offline · ${pendingCount.value} pending` : 'Offline'
     }
     if (lastSyncedAt.value) {
-      return `Synced`
+      return 'Synced'
     }
-    return 'Online · not synced'
+    return 'Online'
   })
 
   function setOnline(value) {
     isOnline.value = Boolean(value)
   }
 
-  async function hydrate(processApi) {
-    enabled.value =
+  function isOfflineCapable(processApi) {
+    return (
       Boolean(processApi?.apitoken) &&
       canUseOfflineSync(processApi.selectedRole, processApi.securityProfile)
+    )
+  }
+
+  function isOfflineMode() {
+    return !isOnline.value || (typeof navigator !== 'undefined' && !navigator.onLine)
+  }
+
+  function clearAutoSyncTimer() {
+    if (autoSyncTimer) {
+      clearTimeout(autoSyncTimer)
+      autoSyncTimer = null
+    }
+  }
+
+  function scheduleAutoSync(processApi, { delayMs = 400 } = {}) {
+    if (!isOfflineCapable(processApi) || !processApi?.apitoken) {
+      return
+    }
+    if (!isOnline.value || (typeof navigator !== 'undefined' && !navigator.onLine)) {
+      return
+    }
+    clearAutoSyncTimer()
+    autoSyncTimer = setTimeout(() => {
+      autoSyncTimer = null
+      if (isSyncing.value) {
+        return
+      }
+      syncNow(processApi).catch(() => {
+        // Errors surface via status label.
+      })
+    }, delayMs)
+  }
+
+  async function hydrate(processApi) {
+    enabled.value = isOfflineCapable(processApi)
     if (!enabled.value || !processApi.organizer || !processApi.eventSlug) {
       index.value = null
-      return
+      return { ok: false }
     }
     try {
       index.value = await loadOfflineIndex({
@@ -59,9 +102,11 @@ export const useOfflineSyncStore = defineStore('offlineSync', () => {
         apitoken: processApi.apitoken
       })
       lastSyncedAt.value = index.value.lastSyncedAt
+      return { ok: true, index: index.value }
     } catch {
       index.value = null
       lastError.value = 'Could not load offline snapshot'
+      return { ok: false, error: lastError.value }
     }
   }
 
@@ -112,10 +157,18 @@ export const useOfflineSyncStore = defineStore('offlineSync', () => {
     if (!index.value) {
       return []
     }
-    return searchPositions(index.value, query)
+    return searchPositions(index.value, query).map(positionToSearchOrder)
+  }
+
+  function searchStored(query = '', { limit = 100 } = {}) {
+    if (!index.value) {
+      return []
+    }
+    return listStoredPositions(index.value, query, { limit }).map(positionToSearchOrder)
   }
 
   async function wipe() {
+    clearAutoSyncTimer()
     await wipeOfflineData()
     index.value = null
     lastSyncedAt.value = null
@@ -133,12 +186,17 @@ export const useOfflineSyncStore = defineStore('offlineSync', () => {
     lastCounts,
     enabled,
     pendingCount,
+    hasSnapshotData,
     statusLabel,
     setOnline,
+    isOfflineCapable,
+    isOfflineMode,
     hydrate,
+    scheduleAutoSync,
     syncNow,
     findBySecret,
     search,
+    searchStored,
     wipe
   }
 })

--- a/src/stores/processEventyayCheckIn.js
+++ b/src/stores/processEventyayCheckIn.js
@@ -15,6 +15,14 @@ import { isBadgeCustomizationUnchanged } from '@/utils/badgeCustomization'
 import { shouldUseSilentPrint } from '@/utils/kioskLauncher'
 import { parseQrPayload } from '@/utils/session'
 import { useCheckinSettingsStore } from '@/stores/checkinSettings'
+import { useOfflineSyncStore } from '@/stores/offlineSync'
+import {
+  applyLocalCheckin,
+  enqueuePendingRedeem,
+  evaluateLocalRedeem,
+  isBrowserOffline
+} from '@/offline/offlineActions'
+import { persistOfflineIndex } from '@/offline/syncEngine'
 
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
@@ -747,6 +755,80 @@ export const useProcessEventyayCheckInStore = defineStore('processEventyayCheckI
     }
   }
 
+  async function redeemOfflineBySecret(
+    normalizedSecret,
+    { type = 'entry', hints = {}, suppressSuccess = false, processApi, apitoken } = {}
+  ) {
+    const offlineSync = useOfflineSyncStore()
+    if (!offlineSync.index) {
+      await offlineSync.hydrate(processApi)
+    }
+    const selectedList = getSelectedCheckInList()
+    const listId = selectedList?.id || processApi.selectedCheckInListId
+    if (!listId) {
+      showErrorMsg(
+        buildAttendeeMessage('No check-in lists are configured for this event.', null, normalizedSecret)
+      )
+      return null
+    }
+
+    const evaluation = evaluateLocalRedeem(offlineSync.index, normalizedSecret, { listId, type })
+    if (!evaluation.ok) {
+      showErrorMsg(
+        buildAttendeeMessage(evaluation.message, evaluation.position || null, normalizedSecret, hints)
+      )
+      return { status: 'error', reason: evaluation.reason }
+    }
+
+    const nonce = generateNonce()
+    const datetime = new Date().toISOString()
+    let position = evaluation.position
+    if (!evaluation.alreadyRedeemed) {
+      position = applyLocalCheckin(offlineSync.index, position, { listId, type, datetime })
+      enqueuePendingRedeem(offlineSync.index, {
+        secret: normalizedSecret,
+        lists: [Number(listId)],
+        type,
+        nonce,
+        datetime
+      })
+      await persistOfflineIndex(offlineSync.index, { apitoken })
+    }
+
+    const synthetic = {
+      status: evaluation.alreadyRedeemed ? 'redeemed' : 'ok',
+      position: {
+        id: position.id,
+        secret: position.secret,
+        attendee_name: position.attendeeName,
+        attendee_email: position.attendeeEmail,
+        company: position.company,
+        job_title: position.jobTitle,
+        product: position.product,
+        checkins: position.checkins,
+        pdf_data: position.pdfData,
+        downloads: []
+      },
+      offline: true
+    }
+
+    if (!suppressSuccess) {
+      showSuccessMsg(
+        buildAttendeeMessage(
+          evaluation.alreadyRedeemed ? getCheckInResultMessage('redeemed') : getCheckInResultMessage('ok'),
+          synthetic.position,
+          normalizedSecret,
+          {
+            ...hints,
+            alreadyCheckedIn: evaluation.alreadyRedeemed,
+            submessage: 'Saved offline — will sync when online'
+          }
+        )
+      )
+    }
+    return synthetic
+  }
+
   async function redeemBySecret(secret, { type = 'entry', attendeeHints = null, isRetry = false, suppressSuccess = false } = {}) {
     const hints = attendeeHints || {}
     const normalizedSecret = String(secret || '').trim()
@@ -760,6 +842,17 @@ export const useProcessEventyayCheckInStore = defineStore('processEventyayCheckI
     if (!url || !apitoken || !organizer) {
       showErrorMsg(buildAttendeeMessage('Device is not configured for check-in.', null, normalizedSecret))
       return null
+    }
+
+    const offlineSync = useOfflineSyncStore()
+    if (isBrowserOffline() && offlineSync.enabled) {
+      return redeemOfflineBySecret(normalizedSecret, {
+        type,
+        hints,
+        suppressSuccess,
+        processApi,
+        apitoken
+      })
     }
 
     try {
@@ -890,6 +983,18 @@ export const useProcessEventyayCheckInStore = defineStore('processEventyayCheckI
               : 'This code is not valid for this event.',
             { hideHttpStatusText: true }
           )
+
+      // Network failure with a synced local copy: fall back to offline redeem once.
+      if (!isRetry && isRedeemNetworkError(error) && offlineSync.enabled) {
+        return redeemOfflineBySecret(normalizedSecret, {
+          type,
+          hints,
+          suppressSuccess,
+          processApi,
+          apitoken
+        })
+      }
+
       showSimpleScanError(fallbackMessage, normalizedSecret, {
         ...hints,
         errorReason: 'invalid'


### PR DESCRIPTION
## Summary
Offline redeem + live-registration queues:
- Local eligibility / stable-nonce queue when offline or network fails
- Unknown ticket → connect to refresh check-in data
- Offline live registration queues create-order (no invented secrets)
- Sync flush uploads pending redeems, then registrations

**Depends on:** #139 (merge #139 first) and https://github.com/fossasia/eventyay/pull/4856  
**Issue:** https://github.com/fossasia/eventyay-checkin/issues/103  

**Merge order:** **2/4 — merge after #139**, before #141–#142. After #139 lands, rebase this branch onto `development` before merging.

## Testing guide

### Prerequisites
- Backend with [eventyay#4856](https://github.com/fossasia/eventyay/pull/4856).
- This branch includes #139 (sync snapshot). Prefer testing the tip of this PR.
- Known attendee ticket secret already in the event; Check-In Staff device paired.

### Automated
```bash
npm ci
npm run test:unit -- --run
npm run lint
```

### Manual — Offline redeem & live registration
1. Online: Sync once so the snapshot includes a known ticket.
2. Go offline (DevTools → Network → Offline, or disconnect Wi‑Fi).
3. **Known ticket**
   - Scan / redeem → success UI.
   - Navbar shows pending count (e.g. `Offline · N pending`).
4. **Unknown / unsynced ticket**
   - Redeem → message to connect and fetch latest check-in data (not a silent failure).
5. **Live registration (offline)**
   - Register a walk-up → UI shows registration queued (no invented secret required online).
   - Pending count increases.
6. Go **online** again → Sync / auto-sync:
   - Pending redeems flush first, then registrations.
   - Pending count returns to 0; server shows the check-ins / new order.

### Checklist
- [x] Unit tests pass on this branch
- [ ] Offline known ticket → success + pending
- [ ] Offline unknown ticket → reconnect message
- [ ] Offline live-reg → queued
- [ ] Reconnect Sync flushes redeems then registrations