### PR TITLE
Replace token setup server URL with origin website presets

### DIFF
--- a/src/components/Common/OriginWebsiteField.vue
+++ b/src/components/Common/OriginWebsiteField.vue
@@ -1,0 +1,46 @@
+<script setup>
+import { computed } from 'vue'
+import {
+  CUSTOM_ORIGIN_WEBSITE,
+  DEFAULT_ORIGIN_WEBSITE,
+  ORIGIN_WEBSITE_OPTIONS
+} from '@/utils/originWebsites'
+
+const selected = defineModel('selected', { type: String, default: DEFAULT_ORIGIN_WEBSITE })
+const customUrl = defineModel('customUrl', { type: String, default: '' })
+
+const isCustom = computed(() => selected.value === CUSTOM_ORIGIN_WEBSITE)
+</script>
+
+<template>
+  <div class="space-y-3">
+    <div>
+      <label for="origin-website" class="block text-xs font-semibold text-body-muted uppercase">
+        Origin website
+      </label>
+      <select
+        id="origin-website"
+        v-model="selected"
+        class="mt-1 block w-full rounded-xl border border-surface-border bg-surface-muted px-3 py-2 text-sm text-body focus:border-primary focus:outline-none"
+      >
+        <option v-for="option in ORIGIN_WEBSITE_OPTIONS" :key="option.value" :value="option.value">
+          {{ option.label }}
+        </option>
+      </select>
+    </div>
+    <div v-if="isCustom">
+      <label for="custom-origin-url" class="block text-xs font-semibold text-body-muted uppercase">
+        Custom URL
+      </label>
+      <input
+        id="custom-origin-url"
+        v-model="customUrl"
+        type="url"
+        inputmode="url"
+        autocomplete="url"
+        placeholder="https://example.eventyay.com"
+        class="mt-1 block w-full rounded-xl border border-surface-border bg-surface-muted px-3 py-2 text-sm text-body focus:border-primary focus:outline-none"
+      />
+    </div>
+  </div>
+</template>

--- a/src/components/Eventyay/EventyayEvents.vue
+++ b/src/components/Eventyay/EventyayEvents.vue
@@ -5,6 +5,7 @@ import { useRouter } from 'vue-router'
 import StandardButton from '@/components/Common/StandardButton.vue'
 import { useEventyayApi } from '@/stores/eventyayapi'
 import { useEventyayEventStore } from '@/stores/eventyayEvent'
+import { useleedauth } from '@/stores/leedauth'
 import { useProcessEventyayCheckInStore } from '@/stores/processEventyayCheckIn'
 import { useLoadingStore } from '@/stores/loading'
 import { getRoleRouteName } from '@/utils/session'
@@ -17,6 +18,7 @@ const EVENTS_PER_PAGE = 8
 const loadingStore = useLoadingStore()
 const router = useRouter()
 const processApi = useEventyayApi()
+const leedauth = useleedauth()
 const eventyayEventStore = useEventyayEventStore()
 const { selectedRole, limitCheckInLists } = storeToRefs(processApi)
 const { events, error } = storeToRefs(eventyayEventStore)
@@ -201,7 +203,7 @@ const checkInListEmptyMessage = computed(() => {
   return 'No check-in lists found for this event. Create a check-in list in the event settings first.'
 })
 
-const submitForm = () => {
+const submitForm = async () => {
   if (!selectedEvent.value) {
     return
   }
@@ -214,6 +216,14 @@ const submitForm = () => {
   processApi.setEvent(selectedEventData.slug, getEventName(selectedEventData))
   if (selectedRole.value !== 'Exhibitor' && selectedCheckInListId.value) {
     processApi.setSelectedCheckInListId(selectedCheckInListId.value)
+  }
+
+  if (selectedRole.value === 'Exhibitor' && processApi.pendingExhibitorKey) {
+    const response = await leedauth.loginWithPendingKey()
+    if (response.success) {
+      router.push({ name: 'leadscan' })
+      return
+    }
   }
 
   const routeName = getRoleRouteName(selectedRole.value)

--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -3,10 +3,13 @@ import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import QRCamera from '@/components/Utilities/QRCamera.vue'
 import StandardButton from '@/components/Common/StandardButton.vue'
+import OriginWebsiteField from '@/components/Common/OriginWebsiteField.vue'
 import KioskLauncherInstructions from '@/components/Common/KioskLauncherInstructions.vue'
 import { useCameraStore } from '@/stores/camera'
 import { useEventyayApi } from '@/stores/eventyayapi'
+import { useleedauth } from '@/stores/leedauth'
 import { useLoadingStore } from '@/stores/loading'
+import { DEFAULT_ORIGIN_WEBSITE, resolveOriginWebsite } from '@/utils/originWebsites'
 import { getEventyayLogoProps, getRoleLabel, getRoleRouteName, STATION_TYPE_DEFINITIONS } from '@/utils/session'
 import { isRoleAllowedForProfile, getAllowedRolesForProfile } from '@/utils/deviceProfiles'
 import { buildKioskUrl, isKioskEnvironment } from '@/utils/kioskLauncher'
@@ -14,6 +17,7 @@ import { UserGroupIcon, PrinterIcon, BuildingStorefrontIcon } from '@heroicons/v
 
 const loadingStore = useLoadingStore()
 const processApi = useEventyayApi()
+const leedauth = useleedauth()
 const cameraStore = useCameraStore()
 const router = useRouter()
 const route = useRoute()
@@ -81,6 +85,25 @@ function redirectForRole(role) {
 function redirectAfterRegistration(role) {
   if (!isRoleAllowedForProfile(role, processApi.securityProfile)) {
     router.push({ name: 'profileMismatch' })
+    return
+  }
+  redirectForRole(role)
+}
+
+async function redirectAfterExhibitorRegistration(role) {
+  if (!isRoleAllowedForProfile(role, processApi.securityProfile)) {
+    router.push({ name: 'profileMismatch' })
+    return
+  }
+
+  if (!processApi.eventSlug) {
+    redirectForRole(role)
+    return
+  }
+
+  const response = await leedauth.loginWithPendingKey()
+  if (response.success) {
+    router.push({ name: 'leadscan' })
     return
   }
   redirectForRole(role)
@@ -160,16 +183,19 @@ async function handleQrScanned() {
 }
 
 const showManualInput = ref(false)
-const manualUrl = ref('')
+const originWebsite = ref(DEFAULT_ORIGIN_WEBSITE)
+const customOriginUrl = ref('')
 const manualToken = ref('')
-const serverUrlPlaceholder = 'https://eventyay.com'
+const manualExhibitorKey = ref('')
+const isExhibitorRegistration = computed(() => pendingRole.value === 'Exhibitor')
 
 async function handleManualRegister() {
-  const urlVal = manualUrl.value.trim()
+  const urlVal = resolveOriginWebsite(originWebsite.value, customOriginUrl.value)
   const tokenVal = manualToken.value.trim()
+  const exhibitorKey = isExhibitorRegistration.value ? manualExhibitorKey.value.trim() : ''
 
   if (!urlVal || !tokenVal) {
-    errmessage.value = 'Please provide both the Server URL and Setup Token.'
+    errmessage.value = 'Please provide both the origin website and setup token.'
     showError.value = true
     return
   }
@@ -180,17 +206,23 @@ async function handleManualRegister() {
   try {
     const result = await processApi.registerDeviceManually(urlVal, tokenVal)
     if (result.success) {
+      processApi.setPendingExhibitorKey(exhibitorKey)
       showScanner.value = false
       showManualInput.value = false
-      redirectAfterRegistration(pendingRole.value || processApi.selectedRole)
+      const role = pendingRole.value || processApi.selectedRole
+      if (role === 'Exhibitor' && exhibitorKey) {
+        await redirectAfterExhibitorRegistration(role)
+      } else {
+        redirectAfterRegistration(role)
+      }
     } else if (result.error === 'invalid_url') {
-      errmessage.value = 'Invalid Server URL. Please enter a valid URL.'
+      errmessage.value = 'Invalid origin website. Please enter a valid URL.'
       showError.value = true
     } else if (result.message) {
       errmessage.value = result.message
       showError.value = true
     } else {
-      errmessage.value = 'Registration failed. Please check the Server URL and Setup Token.'
+      errmessage.value = 'Registration failed. Please check the origin website and setup token.'
       showError.value = true
     }
   } catch (error) {
@@ -314,16 +346,7 @@ loadingStore.contentLoaded()
               </p>
             </div>
             <div class="space-y-3 text-left">
-              <div>
-                <label for="manual-url" class="block text-xs font-semibold text-body-muted uppercase">Server URL</label>
-                <input
-                  id="manual-url"
-                  v-model="manualUrl"
-                  type="text"
-                  :placeholder="serverUrlPlaceholder"
-                  class="mt-1 block w-full rounded-xl border border-surface-border bg-surface-muted px-3 py-2 text-sm text-body focus:border-primary focus:outline-none"
-                />
-              </div>
+              <OriginWebsiteField v-model:selected="originWebsite" v-model:custom-url="customOriginUrl" />
               <div>
                 <label for="manual-token" class="block text-xs font-semibold text-body-muted uppercase">Setup Token</label>
                 <input
@@ -331,6 +354,19 @@ loadingStore.contentLoaded()
                   v-model="manualToken"
                   type="password"
                   placeholder="Enter your registration token"
+                  class="mt-1 block w-full rounded-xl border border-surface-border bg-surface-muted px-3 py-2 text-sm text-body focus:border-primary focus:outline-none"
+                />
+              </div>
+              <div v-if="isExhibitorRegistration">
+                <label for="manual-exhibitor-key" class="block text-xs font-semibold text-body-muted uppercase">
+                  Exhibitor key
+                </label>
+                <input
+                  id="manual-exhibitor-key"
+                  v-model="manualExhibitorKey"
+                  type="password"
+                  autocomplete="off"
+                  placeholder="Optional — you can also enter this after event selection"
                   class="mt-1 block w-full rounded-xl border border-surface-border bg-surface-muted px-3 py-2 text-sm text-body focus:border-primary focus:outline-none"
                 />
               </div>

--- a/src/stores/eventyayapi.js
+++ b/src/stores/eventyayapi.js
@@ -22,6 +22,7 @@ export const useEventyayApi = defineStore(
     const deviceName = ref('')
     const gateName = ref('')
     const securityProfile = ref('')
+    const pendingExhibitorKey = ref('')
 
     function $reset() {
       apitoken.value = ''
@@ -40,6 +41,7 @@ export const useEventyayApi = defineStore(
       deviceName.value = ''
       gateName.value = ''
       securityProfile.value = ''
+      pendingExhibitorKey.value = ''
     }
 
     function parseRegistrationError(error) {
@@ -104,6 +106,10 @@ export const useEventyayApi = defineStore(
       exhiname.value = ''
       boothname.value = ''
       boothid.value = ''
+    }
+
+    function setPendingExhibitorKey(key) {
+      pendingExhibitorKey.value = String(key || '').trim()
     }
 
     function setEvent(slug, name) {
@@ -175,6 +181,7 @@ export const useEventyayApi = defineStore(
       deviceName.value = ''
       gateName.value = ''
       securityProfile.value = ''
+      pendingExhibitorKey.value = ''
 
       if (!clearRole) {
         selectedRole.value = preservedRole
@@ -342,6 +349,8 @@ export const useEventyayApi = defineStore(
       setApiCred,
       setEvent,
       setExhibitor,
+      pendingExhibitorKey,
+      setPendingExhibitorKey,
       selectedRole,
       setRole,
       applyStationTypeChange,

--- a/src/stores/leedauth.js
+++ b/src/stores/leedauth.js
@@ -76,5 +76,17 @@ export const useleedauth = defineStore('leedauth', () => {
     }
   }
 
-  return { leedlogin }
+  async function loginWithPendingKey() {
+    const processApi = useEventyayApi()
+    const pendingKey = String(processApi.pendingExhibitorKey || '').trim()
+    if (!pendingKey) {
+      return { success: false, skipped: true }
+    }
+
+    const response = await leedlogin({ key: pendingKey })
+    processApi.setPendingExhibitorKey('')
+    return response
+  }
+
+  return { leedlogin, loginWithPendingKey }
 })

--- a/src/utils/__tests__/originWebsites.spec.js
+++ b/src/utils/__tests__/originWebsites.spec.js
@@ -1,9 +1,9 @@
-import { describe, expect, it } from 'vitest'
 import {
   CUSTOM_ORIGIN_WEBSITE,
   DEFAULT_ORIGIN_WEBSITE,
   resolveOriginWebsite
 } from '@/utils/originWebsites'
+import { describe, expect, it } from 'vitest'
 
 describe('resolveOriginWebsite', () => {
   it('returns the selected origin website', () => {

--- a/src/utils/__tests__/originWebsites.spec.js
+++ b/src/utils/__tests__/originWebsites.spec.js
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CUSTOM_ORIGIN_WEBSITE,
+  DEFAULT_ORIGIN_WEBSITE,
+  resolveOriginWebsite
+} from '@/utils/originWebsites'
+
+describe('resolveOriginWebsite', () => {
+  it('returns the selected origin website', () => {
+    expect(resolveOriginWebsite(DEFAULT_ORIGIN_WEBSITE)).toBe(DEFAULT_ORIGIN_WEBSITE)
+  })
+
+  it('returns the custom URL when custom is selected', () => {
+    expect(resolveOriginWebsite(CUSTOM_ORIGIN_WEBSITE, ' https://local.test/ ')).toBe(
+      'https://local.test/'
+    )
+  })
+
+  it('returns an empty string when custom is selected without a URL', () => {
+    expect(resolveOriginWebsite(CUSTOM_ORIGIN_WEBSITE, '  ')).toBe('')
+  })
+})

--- a/src/utils/originWebsites.js
+++ b/src/utils/originWebsites.js
@@ -1,0 +1,17 @@
+export const CUSTOM_ORIGIN_WEBSITE = 'custom'
+
+export const DEFAULT_ORIGIN_WEBSITE = 'https://eventyay.com'
+
+export const ORIGIN_WEBSITE_OPTIONS = [
+  { value: 'https://dev.eventyay.com', label: 'https://dev.eventyay.com' },
+  { value: 'https://eventyay.com', label: 'https://eventyay.com' },
+  { value: 'https://wikimedia.eventyay.com', label: 'https://wikimedia.eventyay.com' },
+  { value: CUSTOM_ORIGIN_WEBSITE, label: 'Custom' }
+]
+
+export function resolveOriginWebsite(choice, customUrl = '') {
+  if (choice === CUSTOM_ORIGIN_WEBSITE) {
+    return String(customUrl || '').trim()
+  }
+  return String(choice || '').trim()
+}


### PR DESCRIPTION
## Summary
- Replace free-text server URL on manual device registration with an **Origin website** dropdown (`dev.eventyay.com`, `eventyay.com`, `wikimedia.eventyay.com`, plus Custom).
- On exhibitor **manual** registration, allow entering the exhibitor key on the same form; QR registration still asks for the key after scan / event selection.
- Fixes fossasia/eventyay-checkin#143

## Test plan
- [ ] Check-in / badge station: QR registration still works; no exhibitor key field on the scanner.
- [ ] Manual registration: pick a preset origin, enter setup token, register successfully.
- [ ] Manual registration: choose Custom, enter a URL, register successfully.
- [ ] Exhibitor QR: after scan (and event pick if needed), exhibitor key screen still appears.
- [ ] Exhibitor manual: enter origin, token, and exhibitor key; after event selection, lead scan opens without a second key prompt when the key is valid.
- [ ] Exhibitor manual: omit exhibitor key; sign-in screen still appears after event selection.

## Summary by Sourcery

Replace manual device registration server URL input with preset origin website selection and streamline exhibitor manual registration to optionally include the exhibitor key before event selection.

New Features:
- Add an origin website selector with presets and custom URL support for manual device registration.
- Allow exhibitors to enter an optional exhibitor key during manual registration to proceed directly to lead scanning when valid.

Bug Fixes:
- Ensure exhibitor manual registration no longer prompts for the exhibitor key twice when a valid key is provided upfront.

Enhancements:
- Introduce shared origin website utilities and component to standardize origin handling and validation messages across manual registration flows.
- Persist and reuse a pending exhibitor key through event selection, falling back to the existing sign-in flow when the key is missing or invalid.

Tests:
- Add unit tests for origin website resolution, including custom URL handling and empty custom selections.